### PR TITLE
Fix additional API integration tests

### DIFF
--- a/integration_tests/api/insert_sample_data.py
+++ b/integration_tests/api/insert_sample_data.py
@@ -188,8 +188,6 @@ def add_manager(txn):
 @hooks.before('/api/roles/{id}/admins > DELETE > 200 > application/json')
 @hooks.before('/api/roles/{id}/members > DELETE > 200 > application/json')
 @hooks.before('/api/roles/{id}/owners > DELETE > 200 > application/json')
-@hooks.before('/api/tasks/{id}/admins > DELETE > 200 > application/json')
-@hooks.before('/api/tasks/{id}/owners > DELETE > 200 > application/json')
 @hooks.before('/api/roles/{id}/admins > POST > 200 > application/json')
 @hooks.before('/api/roles/{id}/members > POST > 200 > application/json')
 @hooks.before('/api/roles/{id}/owners > POST > 200 > application/json')
@@ -200,3 +198,9 @@ def add_manager(txn):
 def add_manager_id(txn):
     txn['request']['headers']['Authorization'] = seeded_data['manager_auth']
     patch_body(txn, {'id': seeded_data['manager']['id']})
+
+
+@hooks.before('/api/tasks/{id}/admins > DELETE > 200 > application/json')
+@hooks.before('/api/tasks/{id}/owners > DELETE > 200 > application/json')
+def add_user_id(txn):
+    patch_body(txn, {'id': seeded_data['user']['id']})

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -863,7 +863,7 @@ paths:
         - Bearer: []
       description: Remove an administrator from a particular task
       parameters:
-        - name: member
+        - name: administrator
           in: body
           description: User to be removed from the task's administrator list
           required: true
@@ -954,7 +954,7 @@ paths:
         - Bearer: []
       description: Remove an owner from a particular task
       parameters:
-        - name: member
+        - name: owner
           in: body
           description: User to be removed from the role's owner list
           required: true
@@ -1651,6 +1651,7 @@ definitions:
           - OPEN
           - APPROVED
           - REJECTED
+          - CONFIRMED
       opener:
         type: string
         description: Id of the user who created the proposal


### PR DESCRIPTION
After this update, all API integration tests pass except for `DELETE (200) /api/roles/{id}/tasks` which requires a more complicated setup than is currently provided in `insert_sample_data.py`.