### PR TITLE
Fix incorrect hostname for rbac-server in compose YAML

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -33,7 +33,7 @@ services:
       - ledger-sync
       - rethink
       - validator
-    command: ./bin/rbac-server --host server --db-host rethink --validator-host validator
+    command: ./bin/rbac-server --host 0.0.0.0 --db-host rethink --validator-host validator
 
   rethink:
     image: rethinkdb:2.3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
       - ledger-sync
       - rethink
       - validator
-    command: ./bin/rbac-server --host server --db-host rethink --validator-host validator
+    command: ./bin/rbac-server --host 0.0.0.0 --db-host rethink --validator-host validator
 
   rethink:
     image: rethinkdb:2.3
@@ -81,7 +81,7 @@ services:
     depends_on:
       - rbac-server
     environment:
-      - RBAC_SERVER=rbac-server
+      - RBAC_SERVER=localhost
 
   rest-api:
     image: hyperledger/sawtooth-rest-api:1.0


### PR DESCRIPTION
Changes the hostname the UI connects to in the compose file to `localhost` and sets the `--host` to `0.0.0.0` at server startup.