### PR TITLE
Allow docker image build without config.py

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -37,8 +37,6 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F10
 ENV LC_ALL=en_US.UTF-8
 WORKDIR /project/tmobile-rbac
 
-COPY server/config.py server/config.py
-
 # Note that the context must be set to the project's root directory
 COPY bin/protogen bin/protogen
 COPY protos/ protos/


### PR DESCRIPTION
The config.py is configuration, and should not prevent the build of the server image.  It is still required for running the server image obviously, and the example is there to build off of.