### PR TITLE
Issue#19 Request reasoning fix

### DIFF
--- a/ui/src/app/modals/add-member-modal/add-member-modal.component.ts
+++ b/ui/src/app/modals/add-member-modal/add-member-modal.component.ts
@@ -60,7 +60,7 @@ export class AddMemberModalComponent {
 
     addMember() {
         this.pageLoader.startLoading();
-        this.groupService.addMemberToGroup(this.group.id, this.addMemberForm.value)
+        this.groupService.addMemberToGroup(this.group.id, this.addMemberForm.value, '')
             .then((response) => {
                 this.onAdd.emit(this.addMemberForm.value);
                 this.pageLoader.startLoading();

--- a/ui/src/app/modals/request-access-modal/request-access-modal.component.html
+++ b/ui/src/app/modals/request-access-modal/request-access-modal.component.html
@@ -23,11 +23,15 @@ limitations under the License.
                 <i class="icon-icon-close hd-clickable"></i>
             </div>
             <div class="modal-content">
-                <div class="modal-textarea">
-                    What's the reason for your request (Max 60 characters).
-                    <textarea placeholder="Enter reason..." maxlength="60" rows="6" value=""></textarea>
+                <p>What's the reason for your request (Max 60 characters).</p>
+                <app-form-input [label]="'Enter reasoning...'"
+                                [(throwError)]="throwError"
+                                [(value)]="reason">
+                </app-form-input>
+                <div class="modal-message">
+                    <p *ngIf="throwError" class="text-pink">
+                        Your reason can only be 60 characters max.</p>
                 </div>
-                <div class="modal-message"></div>
             </div>
 
             <ul class="modal-options-horizontal">

--- a/ui/src/app/modals/request-access-modal/request-access-modal.component.html
+++ b/ui/src/app/modals/request-access-modal/request-access-modal.component.html
@@ -23,14 +23,10 @@ limitations under the License.
                 <i class="icon-icon-close hd-clickable"></i>
             </div>
             <div class="modal-content">
-                <p>What's the reason for your request (Max 60 characters).</p>
-                <app-form-input [label]="'Enter reasoning...'"
-                                [(throwError)]="throwError"
-                                [(value)]="reason">
-                </app-form-input>
-                <div class="modal-message">
-                    <p *ngIf="throwError" class="text-pink">
-                        Your reason can only be 60 characters max.</p>
+                <div class="modal-textarea">
+                    What's the reason for your request (Max 60 characters).
+                    <textarea [(ngModel)]="reason" placeholder="Enter reason..." maxlength="60" rows="6" value=""></textarea>
+                    <div class="modal-message"></div>
                 </div>
             </div>
 

--- a/ui/src/app/modals/request-access-modal/request-access-modal.component.ts
+++ b/ui/src/app/modals/request-access-modal/request-access-modal.component.ts
@@ -36,6 +36,8 @@ export class RequestAccessModalComponent {
     }
 
     private _show;
+    public reason;
+    public throwError = false;
     @Output() showChange = new EventEmitter();
     @Input() group;
 
@@ -54,7 +56,11 @@ export class RequestAccessModalComponent {
     }
 
     requestAccess() {
-        this.groupService.addMemberToGroup(this.group.id, this.context.getUser())
+        if(this.reason.length > 60) {
+            this.throwError = true;
+        } else {
+            this.throwError = false;
+            this.groupService.addMemberToGroup(this.group.id, this.context.getUser(), this.reason)
             .then((response) => {
 
                 console.log('Request Access Response: ', response);
@@ -63,6 +69,7 @@ export class RequestAccessModalComponent {
                 this.close();
                 this.utils.defaultSnackBar('Request Sent')
             });
+        }
     }
 
 }

--- a/ui/src/app/modals/request-access-modal/request-access-modal.component.ts
+++ b/ui/src/app/modals/request-access-modal/request-access-modal.component.ts
@@ -37,7 +37,6 @@ export class RequestAccessModalComponent {
 
     private _show;
     public reason;
-    public throwError = false;
     @Output() showChange = new EventEmitter();
     @Input() group;
 
@@ -56,20 +55,14 @@ export class RequestAccessModalComponent {
     }
 
     requestAccess() {
-        if(this.reason.length > 60) {
-            this.throwError = true;
-        } else {
-            this.throwError = false;
-            this.groupService.addMemberToGroup(this.group.id, this.context.getUser(), this.reason)
-            .then((response) => {
-
-                console.log('Request Access Response: ', response);
-                let user = this.context.getUser();
-                user.proposals.push(response.id);
-                this.close();
-                this.utils.defaultSnackBar('Request Sent')
-            });
-        }
+        this.groupService.addMemberToGroup(this.group.id, this.context.getUser(), this.reason)
+        .then((response) => {
+            console.log('Request Access Response: ', response);
+            let user = this.context.getUser();
+            user.proposals.push(response.id);
+            this.close();
+            this.utils.defaultSnackBar('Request Sent')
+        });
     }
 
 }

--- a/ui/src/app/pages/pending-approval/pending-approval.component.ts
+++ b/ui/src/app/pages/pending-approval/pending-approval.component.ts
@@ -47,7 +47,7 @@ export class PendingApprovalComponent implements OnInit {
                 new TableHeader('Group Name', '', 'function', (element) => {
                     return _.find(this.allGroups, {id: element.object}).name;
                 }),
-                new TableHeader('Reason', 'openReason', 'string'),
+                new TableHeader('Reason', 'open_reason', 'string'),
                 new TableHeader('Owner', '', 'function', (element) => {
                     let group = _.find(this.allGroups, {id: element.object});
                     return this.usersUtils.displayOwners(group, this.user);

--- a/ui/src/app/pages/requests/requests.component.ts
+++ b/ui/src/app/pages/requests/requests.component.ts
@@ -55,7 +55,7 @@ export class RequestsComponent {
                 new TableHeader('Group Requested', '', 'function', (element) => {
                     return this.groupUtils.getGroup(element.object).name;
                 }),
-                new TableHeader('Reason', 'openReason', 'string')
+                new TableHeader('Reason', 'open_reason', 'string')
             ],
             actionsComponent: RequestsActionsComponent
         };

--- a/ui/src/app/services/groups/group.service.ts
+++ b/ui/src/app/services/groups/group.service.ts
@@ -37,8 +37,8 @@ export class GroupService {
             }).catch(this.utils.catchError)
     }
 
-    addMemberToGroup(groupId, member) {
-        let request = environment.add_member(groupId, member);
+    addMemberToGroup(groupId, member, reason) {
+        let request = environment.add_member(groupId, member, reason);
         return this.http.post(request.url, request.body, this.context.httpOptions())
             .toPromise()
             .then((response) => {

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -24,10 +24,11 @@ export const environment = {
 
     //ROLES API
     roles: base + '/roles',
-    add_member: (roleId, member) => {
+    add_member: (roleId, member, reason) => {
         return {
             body: {
-                id: member.id
+                id: member.id,
+                reason: reason
             },
             url: base + '/roles/' + roleId + '/members'
         }

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -24,7 +24,7 @@ export const environment = {
 
     //ROLES API
     roles: '/api/GROUPS',
-    add_member: (roleId, member) => {
+    add_member: (roleId, member, reason) => {
         return {
             body: {
                 code: 200,


### PR DESCRIPTION
This PR resolves #19. When a user submits a group access request, their inputted reasoning is now being saved with the request. 

After fixing this issue, requests on the 'Requests' and 'Pending Approvals' pages were not displaying the reasoning associated with the request. This PR also fixes this display issue on both pages.