### PR TITLE
Added username to integration tests

### DIFF
--- a/integration_tests/blockchain/blockchain_integration_test.py
+++ b/integration_tests/blockchain/blockchain_integration_test.py
@@ -148,6 +148,7 @@ class TestBlockchain(unittest.TestCase):
         self.assertEqual(
             self.client.create_user(
                 key=self.key1,
+                name=self.user1,
                 user_name=self.user1,
                 user_id=self.key1.public_key)[0]['status'],
             'COMMITTED')
@@ -155,6 +156,7 @@ class TestBlockchain(unittest.TestCase):
         self.assertEqual(
             self.client.create_user(
                 key=self.key1,
+                name=self.user2a,
                 user_name=self.user2a,
                 user_id=self.key2a.public_key,
                 manager_id=self.key1.public_key)[0]['status'],
@@ -163,6 +165,7 @@ class TestBlockchain(unittest.TestCase):
         self.assertEqual(
             self.client.create_user(
                 key=self.key3a,
+                name=self.user2b,
                 user_name=self.user2b,
                 user_id=self.key2b.public_key,
                 manager_id=self.key3a.public_key)[0]['status'],
@@ -173,6 +176,7 @@ class TestBlockchain(unittest.TestCase):
         self.assertEqual(
             self.client.create_user(
                 key=self.key2a,
+                name=self.user1,
                 user_name=self.user1,
                 user_id=self.key2a.public_key,
                 manager_id=self.key1.public_key)[0]['status'],
@@ -182,6 +186,7 @@ class TestBlockchain(unittest.TestCase):
         self.assertEqual(
             self.client.create_user(
                 key=self.key2a,
+                name=self.user2b,
                 user_name=self.user2b,
                 user_id=self.key2b.public_key,
                 manager_id=self.key1.public_key)[0]['status'],
@@ -191,6 +196,7 @@ class TestBlockchain(unittest.TestCase):
         self.assertEqual(
             self.client.create_user(
                 key=self.key_invalid,
+                name=self.user_invalid[:4],
                 user_name=self.user_invalid[:4],
                 user_id=self.key_invalid.public_key,
                 manager_id=None)[0]['status'],
@@ -200,6 +206,7 @@ class TestBlockchain(unittest.TestCase):
         self.assertEqual(
             self.client.create_user(
                 key=self.key2a,
+                name=self.user3a,
                 user_name=self.user3a,
                 user_id=self.key3a.public_key,
                 manager_id=self.key2a.public_key)[0]['status'],
@@ -208,6 +215,7 @@ class TestBlockchain(unittest.TestCase):
         self.assertEqual(
             self.client.create_user(
                 key=self.key1,
+                name=self.user2b,
                 user_name=self.user2b,
                 user_id=self.key2b.public_key,
                 manager_id=self.key1.public_key)[0]['status'],
@@ -216,6 +224,7 @@ class TestBlockchain(unittest.TestCase):
         self.assertEqual(
             self.client.create_user(
                 key=self.key3b,
+                name=self.user3b,
                 user_name=self.user3b,
                 user_id=self.key3b.public_key,
                 manager_id=self.key2b.public_key)[0]['status'],
@@ -1735,13 +1744,14 @@ class RBACClient(object):
                 items.append((user_container, addresser.AddressSpace.USER))
         return items
 
-    def create_user(self, key, user_name, user_id, manager_id=None):
-        batch_list, signature = create_user(key,
-                                            BATCHER_KEY,
-                                            user_name,
-                                            user_id,
-                                            uuid4().hex,
-                                            manager_id)
+    def create_user(self, key, name, user_name, user_id, manager_id=None):
+        batch_list, signature = create_user(txn_key=key,
+                                            batch_key=BATCHER_KEY,
+                                            name=name,
+                                            user_name=user_name,
+                                            user_id=user_id,
+                                            metadata=uuid4().hex,
+                                            manager_id=manager_id)
         self._client.send_batches(batch_list)
         return self._client.get_statuses([signature], wait=10)
 


### PR DESCRIPTION
Integration tests where not updated to reflect the addition of usernames in PR # 13, causing all integration tests to fail.

Command: `bin/build -p && bin/run_docker_test integration_tests/blockchain/docker-compose.yaml`

Fixes: #46 
Signed-off-by: Adam

Note: 10 of 26 integration tests still fail due to Issue #47.
All succeed if run on commit 26e61a26a523e529ec24d8576233e053dc64b146
