### PR TITLE
Reverted proposal signing requirement

### DIFF
--- a/processor/rbac_processor/role/common.py
+++ b/processor/rbac_processor/role/common.py
@@ -69,6 +69,12 @@ def validate_role_rel_proposal(header, propose, rel_address, state, is_remove = 
         return_user_container(user_entry),
         propose.user_id)
 
+    if header.signer_public_key not in [user.user_id, user.manager_id]:
+        raise InvalidTransaction(
+            "Txn signer {} is not the user or the user's "
+            "manager {}".format(header.signer_public_key,
+                                [user.user_id, user.manager_id]))
+
     validate_identifier_is_role(state_entries,
                                 identifier=propose.role_id,
                                 address=role_address)


### PR DESCRIPTION
Integration tests where not updated to reflect change in signing requirements in PR # 18, causing some integration tests to fail.

Integration tests should be added to cover scenarios where this signing requirements do not reflect current implementation, and existing tests should be reviewed and address why they fail if the signing requirements change as previously proposed in PR # 18. 

Command: `bin/build -i`
All 26 test should now succeed.

Fixes Issue #47 