### PR TITLE
Issue #26 fix - task owner/admin permissions

### DIFF
--- a/processor/rbac_processor/handler.py
+++ b/processor/rbac_processor/handler.py
@@ -275,6 +275,12 @@ def apply_task_confirm(header, payload, state):
     elif payload.message_type == RBACPayload.CONFIRM_ADD_TASK_OWNERS:
         task_owners.apply_confirm(header, payload, state)
 
+    elif payload.message_type == RBACPayload.CONFIRM_REMOVE_TASK_ADMINS:
+        task_admins.apply_confirm(header, payload, state, True)
+
+    elif payload.message_type == RBACPayload.CONFIRM_REMOVE_TASK_OWNERS:
+        task_owners.apply_confirm(header, payload, state, True)
+
     else:
         raise InvalidTransaction("Message type unknown.")
 

--- a/processor/rbac_processor/task/common.py
+++ b/processor/rbac_processor/task/common.py
@@ -67,27 +67,30 @@ def validate_task_rel_proposal(header, propose, rel_address, state):
         return_user_container(user_entry),
         propose.user_id)
 
-    if header.signer_public_key not in [user.user_id, user.manager_id]:
-        raise InvalidTransaction(
-            "Txn signer {} is not the user or the user's "
-            "manager {}".format(header.signer_public_key,
-                                [user.user_id, user.manager_id]))
-
     validate_identifier_is_task(state_entries,
                                 identifier=propose.task_id,
                                 address=task_address)
 
     try:
-        task_admins_entry = get_state_entry(state_entries, rel_address)
-        task_rel_container = return_task_rel_container(task_admins_entry)
+        task_rel_entry = get_state_entry(state_entries, rel_address)
+        task_rel_container = return_task_rel_container(task_rel_entry)
+        if (header.signer_public_key not in [user.user_id, user.manager_id]) and (not is_in_task_rel_container(
+                task_rel_container,
+                propose.task_id,
+                propose.user_id)):
+            raise InvalidTransaction(
+                "Txn signer {} is not the user or the user's "
+                "manager {} nor the task owner / admin".format(header.signer_public_key,
+                                                               [user.user_id, user.manager_id]))
         if is_in_task_rel_container(
                 task_rel_container,
                 propose.task_id,
                 propose.user_id):
             raise InvalidTransaction(
-                "User {} is already in the Role {} "
-                "relationship".format(propose.user_id,
+                "User {} is already in the Task {} "
+                "relationship".format(propose.user.id,
                                       propose.task_id))
+
     except KeyError:
         # The task rel container doesn't exist so no task relationship exists
         pass
@@ -134,13 +137,6 @@ def validate_task_rel_del_proposal(header, propose, rel_address, state):
         return_user_container(user_entry),
         propose.user_id)
 
-    if header.signer_public_key not in [user.user_id, user.manager_id]:
-        raise InvalidTransaction(
-            "Txn signer {} is not the user {} or the user's manager {}".format(
-                header.signer_public_key,
-                user.user_id,
-                user.manager_id))
-
     validate_identifier_is_task(state_entries,
                                 identifier=propose.task_id,
                                 address=task_address)
@@ -148,6 +144,16 @@ def validate_task_rel_del_proposal(header, propose, rel_address, state):
     try:
         task_rel_entry = get_state_entry(state_entries, rel_address)
         task_rel_container = return_task_rel_container(task_rel_entry)
+
+        if (header.signer_public_key not in [user.user_id, user.manager_id]) and (not is_in_task_rel_container(
+                task_rel_container,
+                propose.task_id,
+                propose.user_id)):
+            raise InvalidTransaction(
+                "Txn signer {} is not the user or the user's "
+                "manager {} nor the task owner / admin".format(header.signer_public_key,
+                                                               [user.user_id, user.manager_id]))
+
         if not is_in_task_rel_container(
                 task_rel_container,
                 propose.task_id,
@@ -168,13 +174,18 @@ def validate_task_rel_del_proposal(header, propose, rel_address, state):
 def validate_task_admin_or_owner(header,
                                  confirm,
                                  txn_signer_rel_address,
-                                 state):
+                                 task_rel_address,
+                                 state,
+                                 is_remove):
     """Validate a [ Confirm | Reject }_____Task[ Admin | Owner } transaction.
 
     Args:
         header (TransactionHeader): The transaction header protobuf class.:
         confirm: ConfirmAddTaskAdmin, RejectAddTaskAdmin, ...
+        txn_signer_rel_address (str): The transaction signer address.
+        task_rel_address (str): The task relationship address.
         state (Context): The class responsible for gets and sets of state.
+        is_remove (boolean): Determines if task owner is being added or removed.
 
     Returns:
         (dict of addresses)
@@ -184,9 +195,14 @@ def validate_task_admin_or_owner(header,
         object_id=confirm.task_id,
         related_id=confirm.user_id)
 
-    state_entries = get_state(
-        state,
-        [txn_signer_rel_address, proposal_address])
+    if not is_remove:
+        state_entries = get_state(
+            state,
+            [txn_signer_rel_address, proposal_address])
+    else:
+        state_entries = get_state(
+            state,
+            [txn_signer_rel_address, task_rel_address, proposal_address])
 
     if not proposal_exists_and_open(
             state_entries,
@@ -243,11 +259,25 @@ def handle_propose_state_set(state_entries,
     })
 
 
-def handle_confirm_add(state_entries,
-                       header,
-                       confirm,
-                       task_rel_address,
-                       state):
+def handle_confirm(state_entries,
+                   header,
+                   confirm,
+                   task_rel_address,
+                   state,
+                   is_remove):
+    """ Updates proposal and task relationship objects according to the
+        task admin/owner transaction.
+
+        Args:
+            state_entries: List of states for the proposal, task relationship,
+            and task admins object.
+            header (TransactionHeader): The protobuf TransactionHeader.
+            confirm (RBACPayload): The protobuf RBACPayload.
+            task_rel_address (str): The task relationship address.
+            state (Context): The class that handles state gets and sets.
+            is_remove (boolean): Determines if task admin/owner is being removed or added.
+
+    """
     proposal_address = addresser.make_proposal_address(
         object_id=confirm.task_id,
         related_id=confirm.user_id)
@@ -281,7 +311,10 @@ def handle_confirm_add(state_entries,
         task_rel = task_rel_container.relationships.add()
         task_rel.task_id = confirm.task_id
 
-    task_rel.identifiers.append(confirm.user_id)
+    if not is_remove:
+        task_rel.identifiers.append(confirm.user_id)
+    else:
+        task_rel.identifiers.remove(confirm.user_id)
 
     address_values[task_rel_address] = task_rel_container.SerializeToString()
 

--- a/processor/rbac_processor/task/task_admins.py
+++ b/processor/rbac_processor/task/task_admins.py
@@ -142,7 +142,11 @@ def apply_confirm(header, payload, state, is_remove=False):
             - The transaction is invalid.
     """
 
-    confirm_payload = task_transaction_pb2.ConfirmAddTaskAdmin()
+    if not is_remove:
+        confirm_payload = task_transaction_pb2.ConfirmAddTaskAdmin()
+    else:
+        confirm_payload = task_transaction_pb2.ConfirmRemoveTaskAdmin()
+
     confirm_payload.ParseFromString(payload.content)
 
     task_admins_address = addresser.make_task_admins_address(

--- a/processor/rbac_processor/task/task_admins.py
+++ b/processor/rbac_processor/task/task_admins.py
@@ -19,7 +19,7 @@ from rbac_addressing import addresser
 
 from rbac_processor.common import no_open_proposal
 from rbac_processor.task.common import handle_propose_state_set
-from rbac_processor.task.common import handle_confirm_add
+from rbac_processor.task.common import handle_confirm
 from rbac_processor.task.common import handle_reject
 from rbac_processor.task.common import validate_task_rel_proposal
 from rbac_processor.task.common import validate_task_rel_del_proposal
@@ -128,7 +128,20 @@ def apply_propose_remove(header, payload, state):
         state=state)
 
 
-def apply_confirm(header, payload, state):
+def apply_confirm(header, payload, state, is_remove=False):
+    """Apply the (Add | Remove) TaskAdmins transaction.
+
+    Args:
+        header (TransactionHeader): The protobuf TransactionHeader.
+        payload (RBACPayload): The protobuf RBACPayload.
+        state (Context): The class that handles state gets and sets.
+        is_remove (boolean): Determines if task admin is being added or removed.
+
+    Raises:
+        InvalidTransaction:
+            - The transaction is invalid.
+    """
+
     confirm_payload = task_transaction_pb2.ConfirmAddTaskAdmin()
     confirm_payload.ParseFromString(payload.content)
 
@@ -144,14 +157,17 @@ def apply_confirm(header, payload, state):
         header=header,
         confirm=confirm_payload,
         txn_signer_rel_address=txn_signer_admin_address,
-        state=state)
+        task_rel_address=task_admins_address,
+        state=state,
+        is_remove=is_remove)
 
-    handle_confirm_add(
+    handle_confirm(
         state_entries=state_entries,
         header=header,
         confirm=confirm_payload,
         task_rel_address=task_admins_address,
-        state=state)
+        state=state,
+        is_remove=is_remove)
 
 
 def apply_reject(header, payload, state):
@@ -163,9 +179,11 @@ def apply_reject(header, payload, state):
         user_id=header.signer_public_key)
 
     state_entries = validate_task_admin_or_owner(
-        header,
-        reject_payload,
-        txn_signer_admin_address,
-        state)
+        header=header,
+        confirm=reject_payload,
+        txn_signer_rel_address=txn_signer_admin_address,
+        task_rel_address="",
+        state=state,
+        is_remove=False)
 
     handle_reject(state_entries, header, reject_payload, state)

--- a/processor/rbac_processor/task/task_owners.py
+++ b/processor/rbac_processor/task/task_owners.py
@@ -118,7 +118,11 @@ def apply_confirm(header, payload, state, is_remove=False):
             - The transaction is invalid.
     """
 
-    confirm_payload = task_transaction_pb2.ConfirmAddTaskOwner()
+    if not is_remove:
+        confirm_payload = task_transaction_pb2.ConfirmAddTaskOwner()
+    else:
+        confirm_payload = task_transaction_pb2.ConfirmRemoveTaskOwner()
+
     confirm_payload.ParseFromString(payload.content)
 
     task_owners_address = addresser.make_task_owners_address(

--- a/processor/rbac_processor/task/task_owners.py
+++ b/processor/rbac_processor/task/task_owners.py
@@ -18,7 +18,7 @@ from sawtooth_sdk.processor.exceptions import InvalidTransaction
 from rbac_addressing import addresser
 
 from rbac_processor.common import no_open_proposal
-from rbac_processor.task.common import handle_confirm_add
+from rbac_processor.task.common import handle_confirm
 from rbac_processor.task.common import handle_propose_state_set
 from rbac_processor.task.common import handle_reject
 from rbac_processor.task.common import validate_task_rel_proposal
@@ -104,7 +104,20 @@ def apply_propose_remove(header, payload, state):
         state=state)
 
 
-def apply_confirm(header, payload, state):
+def apply_confirm(header, payload, state, is_remove=False):
+    """Apply the (Add | Remove) TaskOwners transaction.
+
+    Args:
+        header (TransactionHeader): The protobuf TransactionHeader.
+        payload (RBACPayload): The protobuf RBACPayload.
+        state (Context): The class that handles state gets and sets.
+        is_remove (boolean): Determines if task owner is being added or removed.
+
+    Raises:
+        InvalidTransaction:
+            - The transaction is invalid.
+    """
+
     confirm_payload = task_transaction_pb2.ConfirmAddTaskOwner()
     confirm_payload.ParseFromString(payload.content)
 
@@ -117,17 +130,20 @@ def apply_confirm(header, payload, state):
         user_id=header.signer_public_key)
 
     state_entries = validate_task_admin_or_owner(
-        header,
-        confirm_payload,
-        txn_signer_admin_address,
-        state)
+        header=header,
+        confirm=confirm_payload,
+        txn_signer_rel_address=txn_signer_admin_address,
+        task_rel_address=task_owners_address,
+        state=state,
+        is_remove=is_remove)
 
-    handle_confirm_add(
+    handle_confirm(
         state_entries=state_entries,
         header=header,
         confirm=confirm_payload,
         task_rel_address=task_owners_address,
-        state=state)
+        state=state,
+        is_remove=is_remove)
 
 
 def apply_reject(header, payload, state):
@@ -139,9 +155,11 @@ def apply_reject(header, payload, state):
         user_id=header.signer_public_key)
 
     state_entries = validate_task_admin_or_owner(
-        header,
-        reject_payload,
-        txn_signer_admin_address,
-        state)
+        header=header,
+        confirm=reject_payload,
+        txn_signer_rel_address=txn_signer_admin_address,
+        task_rel_address="",
+        state=state,
+        is_remove=False)
 
     handle_reject(state_entries, header, reject_payload, state)

--- a/transaction_creation/rbac_transaction_creation/task_transaction_creation.py
+++ b/transaction_creation/rbac_transaction_creation/task_transaction_creation.py
@@ -212,6 +212,7 @@ def confirm_remove_task_admins(txn_key,
 
     inputs = [
         addresser.make_task_admins_address(task_id, txn_key.public_key),
+        addresser.make_task_admins_address(task_id, user_id),
         addresser.make_proposal_address(task_id, user_id)]
 
     outputs = [addresser.make_proposal_address(task_id, user_id),
@@ -398,6 +399,7 @@ def confirm_remove_task_owners(txn_key,
         reason=reason)
 
     inputs = [addresser.make_proposal_address(task_id, user_id),
+              addresser.make_task_owners_address(task_id, user_id),
               addresser.make_task_admins_address(task_id, txn_key.public_key)]
 
     outputs = [addresser.make_proposal_address(task_id, user_id),


### PR DESCRIPTION
This PR fixes #26 and fixes #63. Now, owners and admins for a particular task has the ability to add and remove additional task owners and task admins. Also, open proposals can now be approved by authorized parties.

Here is my integration test results for the changes made in this PR. 
[PR_60_integration_tests_results.txt](https://github.com/hyperledger/sawtooth-next-directory/files/2377083/PR_60_integration_tests_results.txt)

Once this PR has been merged I will create a new because as I attempt to add a task admin that I just removed from a task, I am getting the following error message: 

`{
     "message": "Bad Request: Txn signer 03e25d64ca81318344513d887c4244d53963f9538d8ba12b8d1055410ae0519066 is not the user or the user's manager ['0210adc09ac5ea4eeb3f02188240a21fd7f8886e08cdfc1ef94f90cbfe21086ed0', ''] nor the task owner / admin",
      "code": 400
}`

Further investigation will be needed as I was initially able to add user `0210adc09ac5ea4eeb3f02188240a21fd7f8886e08cdfc1ef94f90cbfe21086ed0` to the task as a task admin. After removing user `0210adc09ac5ea4eeb3f02188240a21fd7f8886e08cdfc1ef94f90cbfe21086ed0` and attempting to add them again to the task, I run into this 400 error code. 