### PR TITLE
Locks sanic version to 0.7.0

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F10
         grpcio-tools \
         itsdangerous \
         rethinkdb \
-        sanic \
+        sanic==0.7.0 \
         pycrypto \
  && locale-gen en_US.UTF-8 \
  && apt-get clean \

--- a/server/Dockerfile-dev
+++ b/server/Dockerfile-dev
@@ -31,7 +31,7 @@ ENV LC_ALL en_US.UTF-8
 RUN pip3 install \
     itsdangerous \
     rethinkdb \
-    sanic \
+    sanic==0.7.0 \
     pycrypto
 
 WORKDIR /project/tmobile-rbac


### PR DESCRIPTION
Locking sanic to version 0.7.0 (instead of using 0.8.x).

Fixes Issue #108

Signed-off-by: Adam Gering