### PR TITLE
Issue #26 fix - task owner/admin permissions (#60)

### DIFF
--- a/integration_tests/blockchain/blockchain_integration_test.py
+++ b/integration_tests/blockchain/blockchain_integration_test.py
@@ -111,6 +111,7 @@ class TestBlockchain(unittest.TestCase):
 
         cls.role_id1 = str(uuid4())
         cls.task_id1 = str(uuid4())
+        cls.task_id2 = str(uuid4())
         cls.update_manager_proposal_id = str(uuid4())
         cls.add_role_admins_proposal_id = str(uuid4())
         cls.add_role_owners_proposal_id = str(uuid4())
@@ -1288,9 +1289,9 @@ class TestBlockchain(unittest.TestCase):
             ProposeAddTaskAdmins validation rules.
                 - The Task exists
                 - The User exists
-                - The txn signer is the User or the User's manager.
+                - The txn signer is the User, the User's manager, or the Task Admin/Owner.
                 - No open proposal exists for the same change.
-                - The user is not already an Admin of the Task.
+                - The User is not already an Admin of the Task.
         """
 
         self.assertEqual(
@@ -1313,18 +1314,18 @@ class TestBlockchain(unittest.TestCase):
                 reason=uuid4().hex,
                 metadata=uuid4().hex)[0]['status'],
             "INVALID",
-            "The user must exist")
+            "The User must exist")
 
         self.assertEqual(
             self.client.propose_add_task_admins(
                 key=self.key1,
                 proposal_id=str(uuid4()),
-                task_id=self.task_id1,
+                task_id=self.task_id2,
                 user_id=self.key3a.public_key,
                 reason=uuid4().hex,
                 metadata=uuid4().hex)[0]['status'],
             "INVALID",
-            "The txn signer must be the user or user's manager")
+            "The txn signer must be the User,  User's manager, or the Task Admin/Owner.")
 
         self.assertEqual(
             self.client.propose_add_task_admins(
@@ -1335,6 +1336,17 @@ class TestBlockchain(unittest.TestCase):
                 reason=uuid4().hex,
                 metadata=uuid4().hex)[0]['status'],
             "COMMITTED")
+        
+        self.assertEqual(
+            self.client.propose_add_task_admins(
+                key=self.key1,
+                proposal_id=str(uuid4()),
+                task_id=self.task_id1,
+                user_id=self.key1.public_key,
+                reason=uuid4().hex,
+                metadata=uuid4().hex)[0]['status'],
+            "INVALID",
+            "The User must not already be an Admin of the Task")
 
         self.assertEqual(
             self.client.propose_add_task_admins(
@@ -1345,7 +1357,7 @@ class TestBlockchain(unittest.TestCase):
                 reason=uuid4().hex,
                 metadata=uuid4().hex)[0]['status'],
             "INVALID",
-            "The must not be any open proposal for the same change.")
+            "There must not be any OPEN proposal for the same change.")
 
     def test_19_confirm_add_task_admins(self):
         """Tests the ConfirmAddTaskAdmins validation rules
@@ -1442,10 +1454,10 @@ class TestBlockchain(unittest.TestCase):
             ProposeAddTaskOwners
                 - The Task exists
                 - The User exists
+                - The txn signer is the User, the User's manager, or the Task Admin/Owner.
                 - No open proposal exists for the same change.
-                - The txn signer is the user or the Users manager.
                 - The User is not already an Owner of the Task.
-        """
+       """
 
         self.assertEqual(
             self.client.propose_add_task_owners(
@@ -1471,25 +1483,14 @@ class TestBlockchain(unittest.TestCase):
 
         self.assertEqual(
             self.client.propose_add_task_owners(
-                key=self.key2a,
-                proposal_id=str(uuid4()),
-                task_id=self.task_id1,
-                user_id=self.key2a.public_key,
-                reason=uuid4().hex,
-                metadata=uuid4().hex)[0]['status'],
-            "INVALID",
-            "The User must not already be an Owner of the Task")
-
-        self.assertEqual(
-            self.client.propose_add_task_owners(
                 key=self.key3a,
                 proposal_id=str(uuid4()),
-                task_id=self.task_id1,
+                task_id=self.task_id2,
                 user_id=self.key2b.public_key,
                 reason=uuid4().hex,
                 metadata=uuid4().hex)[0]['status'],
             "INVALID",
-            "The txn signer must be the User or the Users manager.")
+            "The txn signer must be the User,  User's manager, or the Task Admin/Owner.")
 
         self.assertEqual(
             self.client.propose_add_task_owners(
@@ -1500,6 +1501,18 @@ class TestBlockchain(unittest.TestCase):
                 reason=uuid4().hex,
                 metadata=uuid4().hex)[0]['status'],
             "COMMITTED")
+
+        self.assertEqual(
+            self.client.propose_add_task_owners(
+                key=self.key2a,
+                proposal_id=str(uuid4()),
+                task_id=self.task_id1,
+                user_id=self.key2a.public_key,
+                reason=uuid4().hex,
+                metadata=uuid4().hex)[0]['status'],
+            "INVALID",
+            "The User must not already be an Owner of the Task")
+
 
         self.assertEqual(
             self.client.propose_add_task_owners(
@@ -1518,11 +1531,11 @@ class TestBlockchain(unittest.TestCase):
         Notes
             ConfirmAddTaskOwners validation rules
                 - The proposal exists and is open.
-                - The txn signer is a Task Admin.
+                - The txn signer is a Task Owner.
         """
 
         self.assertEqual(
-            self.client.confirm_add_task_admins(
+            self.client.confirm_add_task_owners(
                 key=self.key1,
                 proposal_id=str(uuid4()),
                 task_id=self.task_id1,
@@ -1609,7 +1622,7 @@ class TestBlockchain(unittest.TestCase):
                 - The user is an admin of the task.
                 - The Task exists
                 - The User exists.
-                - The txn signer is the user or the user's manager.
+                - The txn signer is the User, the User's manager, or the Task Admin/Owner.
         """
 
         self.assertEqual(
@@ -1649,12 +1662,12 @@ class TestBlockchain(unittest.TestCase):
             self.client.propose_delete_task_admins(
                 key=self.key2b,
                 proposal_id=str(uuid4()),
-                task_id=self.task_id1,
+                task_id=self.task_id2,
                 user_id=self.key1.public_key,
                 reason=uuid4().hex,
                 metadata=uuid4().hex)[0]['status'],
             "INVALID",
-            "The txn signer must be the User or the User's Manager.")
+            "The txn signer must be the User, User's manager, or the Task Admin/Owner.")
 
         self.assertEqual(
             self.client.propose_delete_task_admins(
@@ -1675,7 +1688,7 @@ class TestBlockchain(unittest.TestCase):
                 - The user is an Owner of the task.
                 - The Task exists.
                 - The User exists.
-                - The txn signer is the user or the user's manager.
+                - The txn signer is the User, the User's manager, or the Task Admin/Owner.
         """
 
         self.assertEqual(
@@ -1715,12 +1728,12 @@ class TestBlockchain(unittest.TestCase):
             self.client.propose_delete_task_owners(
                 key=self.key2b,
                 proposal_id=str(uuid4()),
-                task_id=self.task_id1,
+                task_id=self.task_id2,
                 user_id=self.key1.public_key,
                 reason=uuid4().hex,
                 metadata=uuid4().hex)[0]['status'],
             "INVALID",
-            "The txn signer must be the User or the User's Manager.")
+            "The txn signer must be the User, User's manager, or the Task Admin/Owner.")
 
         self.assertEqual(
             self.client.propose_delete_task_owners(

--- a/processor/rbac_processor/handler.py
+++ b/processor/rbac_processor/handler.py
@@ -275,6 +275,12 @@ def apply_task_confirm(header, payload, state):
     elif payload.message_type == RBACPayload.CONFIRM_ADD_TASK_OWNERS:
         task_owners.apply_confirm(header, payload, state)
 
+    elif payload.message_type == RBACPayload.CONFIRM_REMOVE_TASK_ADMINS:
+        task_admins.apply_confirm(header, payload, state, True)
+
+    elif payload.message_type == RBACPayload.CONFIRM_REMOVE_TASK_OWNERS:
+        task_owners.apply_confirm(header, payload, state, True)
+
     else:
         raise InvalidTransaction("Message type unknown.")
 

--- a/transaction_creation/rbac_transaction_creation/task_transaction_creation.py
+++ b/transaction_creation/rbac_transaction_creation/task_transaction_creation.py
@@ -212,6 +212,7 @@ def confirm_remove_task_admins(txn_key,
 
     inputs = [
         addresser.make_task_admins_address(task_id, txn_key.public_key),
+        addresser.make_task_admins_address(task_id, user_id),
         addresser.make_proposal_address(task_id, user_id)]
 
     outputs = [addresser.make_proposal_address(task_id, user_id),
@@ -398,6 +399,7 @@ def confirm_remove_task_owners(txn_key,
         reason=reason)
 
     inputs = [addresser.make_proposal_address(task_id, user_id),
+              addresser.make_task_owners_address(task_id, user_id),
               addresser.make_task_admins_address(task_id, txn_key.public_key)]
 
     outputs = [addresser.make_proposal_address(task_id, user_id),


### PR DESCRIPTION
* Fixed task owner's permissions to add and remove

This commit fixes issue #26. Task owners and task admins can now
add additional task owners and task admins and remove them.

Signed-off-by: Michael Nguyen <michael.nguyen79@t-mobile.com>

* Updated integration tests and fixed proposal issue

This commit fixed issue #63. Open proposals can now be approved by
authorized parties. Integration tests were also updated to pass.

Signed-off-by: Michael Nguyen <michael.nguyen79@t-mobile.com>