### PR TITLE
Increases unit test coverage of addresser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.pytest_cache/
 
 # Protobuf
 **/protobuf/

--- a/addressing/rbac_addressing/__init__.py
+++ b/addressing/rbac_addressing/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Intel Corporation
+# Copyright contributors to Hyperledger Sawtooth
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/addressing/rbac_addressing/__tests__/__init__.py
+++ b/addressing/rbac_addressing/__tests__/__init__.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env bash
-
-# Copyright 2017 Intel Corporation
+# Copyright contributors to Hyperledger Sawtooth
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,19 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # -----------------------------------------------------------------------------
-
-
-
-
-TOP_DIR=$(cd $(dirname $(dirname $0)) && pwd)
-
-
-run_tests() {
-
-    python3 -m unittest $@
-
-}
-
-
-export PYTHONPATH=$PYTHONPATH:$TOP_DIR/addressing
-run_tests addressing/tests/test_addresser.py

--- a/addressing/rbac_addressing/__tests__/app.py
+++ b/addressing/rbac_addressing/__tests__/app.py
@@ -1,0 +1,114 @@
+# Copyright contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import unittest
+import logging
+from hashlib import sha512
+from rbac_addressing import addresser
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestAddresser(unittest.TestCase):
+
+    def test_namespace(self):
+        self.assertEqual(addresser.FAMILY_NAME, 'rbac')
+
+        namespace = sha512(addresser.FAMILY_NAME.encode()).hexdigest()[:6]
+
+        self.assertEqual(addresser.NS, namespace)
+        self.assertEqual(addresser.NS, '9f4448')
+
+
+    def test_short_address(self):
+        """Tests that an address that is too short does not validate.
+        """
+
+        address = '9f444847e7570f3f6f7d2c1635f6de\
+eabc1f4d78d9d42b64b70e1819f244138c1e38'
+
+        self.assertFalse(len(address) == addresser.ADDRESS_LENGTH,
+                         "The address is not 70 characters")
+
+        self.assertFalse(addresser.is_address(address),
+                         "The address is not 70 character hexidecimal")
+
+        self.assertFalse(
+            addresser.is_family_address(address),
+            "The address is not 70 character hexidecimal with family prefix")
+
+        with self.assertRaises(ValueError):
+            addresser.address_is(address)
+
+    def test_long_address(self):
+        """Tests that an address that is too long does not validate.
+        """
+
+        address = '9f444847e7570f3f6f7d2c1635f6de\
+eabc1f4d78d9d42b64b70e1819f244138c1e38d6fe'
+
+        self.assertFalse(len(address) == addresser.ADDRESS_LENGTH,
+                         "The address is not 70 characters")
+
+        self.assertFalse(addresser.is_address(address),
+                         "The address is not 70 character hexidecimal")
+
+        self.assertFalse(
+            addresser.is_family_address(address),
+            "The address is not 70 character hexidecimal with family prefix")
+
+        with self.assertRaises(ValueError):
+            addresser.address_is(address)
+
+    def test_nonhex_address(self):
+        """Tests that an address that is not hex does not validate.
+        """
+
+        address = '9f444847e7570f3f6f7d2c1635f6de\
+eabc1f4d78d9d42b64b70e1819f244138c1e38X6'
+
+        self.assertFalse(addresser.is_address(address),
+                         "The address is not 70 character hexidecimal")
+
+        self.assertFalse(
+            addresser.is_family_address(address),
+            "The address is not 70 character hexidecimal with family prefix")
+
+        with self.assertRaises(ValueError):
+            addresser.address_is(address)
+
+    def test_wrong_family_address(self):
+        """Tests that an address with the wrong family prefix
+        does not validate.
+        """
+
+        address = '8f444847e7570f3f6f7d2c1635f6de\
+eabc1f4d78d9d42b64b70e1819f244138c1e38d6'
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertFalse(addresser.namespace_ok(address),
+                         "The address does not have correct namespace prefix")
+
+        self.assertFalse(
+            addresser.is_family_address(address),
+            "The address is not 70 character hexidecimal with family prefix")
+
+        with self.assertRaises(ValueError):
+            addresser.address_is(address)

--- a/addressing/rbac_addressing/__tests__/proposal.py
+++ b/addressing/rbac_addressing/__tests__/proposal.py
@@ -1,0 +1,84 @@
+# Copyright contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import unittest
+import logging
+from uuid import uuid4
+from rbac_addressing import addresser
+from rbac_addressing.addresser import AddressSpace
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestProposalAddresser(unittest.TestCase):
+
+    def test_determine_proposal_addr(self):
+        """Tests that a specific proposal_id generates the expected
+        proposal address, and thus is probably deterministic.
+        """
+
+        object_id = 'cb048d507eec42a5845e20eed982d5d2'
+        related_id = 'f1e916b663164211a9ac34516324681a'
+        expected_address = '9f4448e3b874e90b2bcf58e65e0727\
+91ea499543ee52fc9d0449fc1e41f77d4d4f926e'
+        address = addresser.make_proposal_address(object_id, related_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(address, expected_address,
+                         "The address is the one we expected it to be")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.PROPOSALS,
+            "The address created must be a Proposal address.")
+
+    def test_gen_proposal_addr(self):
+        """Tests the proposal address creation function as well as the
+        address_is function.
+        """
+
+        object_id = uuid4().hex
+        related_id = uuid4().hex
+        address = addresser.make_proposal_address(object_id, related_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.PROPOSALS,
+            "The address created must be a Proposal address.")

--- a/addressing/rbac_addressing/__tests__/role.py
+++ b/addressing/rbac_addressing/__tests__/role.py
@@ -1,0 +1,82 @@
+# Copyright contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import unittest
+import logging
+from uuid import uuid4
+from rbac_addressing import addresser
+from rbac_addressing.addresser import AddressSpace
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestRoleAttributesAddresser(unittest.TestCase):
+
+    def test_deterministic_role_address(self):
+        """Tests that a specific role_id generates the expected
+        role address, and thus is probably deterministic.
+        """
+
+        ident = '99968acb8f1a48b3a4bc21e2cd252e67'
+        expected_address = '9f444809326a1713a905b26359fc8d\
+a2817c1a5f67de6f464701f0c10042da345d2800'
+        address = addresser.make_role_attributes_address(ident)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(address, expected_address,
+                         "The address is the one we expected it to be")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.ROLES_ATTRIBUTES,
+            "The address created must be a Role Attributes address.")
+
+    def test_generated_role_address(self):
+        """Tests the role address creation function as well as the
+        address_is function.
+        """
+
+        ident = uuid4().hex
+        address = addresser.make_role_attributes_address(ident)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.ROLES_ATTRIBUTES,
+            "The address created must be a Role Attributes address.")

--- a/addressing/rbac_addressing/__tests__/role_admins.py
+++ b/addressing/rbac_addressing/__tests__/role_admins.py
@@ -1,0 +1,85 @@
+# Copyright contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import unittest
+import logging
+from uuid import uuid4
+from rbac_addressing import addresser
+from rbac_addressing.addresser import AddressSpace
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestRoleAdminsAddresser(unittest.TestCase):
+
+    def test_determine_role_admin_addr(self):
+        """Tests that a specific role_id and admin_id generates the
+        expected role admin address, and thus is probably deterministic.
+        """
+
+        role_id = '99968acb8f1a48b3a4bc21e2cd252e67'
+        admin_id = '966ab67317234df489adb4bc1f517b88'
+        expected_address = '9f444809326a1713a905b26359fc8d\
+a2817c1a5f67de6f464701f0c10042da345d28f7'
+        address = addresser.make_role_admins_address(role_id, admin_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(address, expected_address,
+                         "The address is the one we expected it to be")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.ROLES_ADMINS,
+            "The address created must be a Role Attributes address.")
+
+
+    def test_generated_role_admin_addr(self):
+        """Tests the role admin address creation function as well as the
+        address_is function.
+        """
+
+        role_id = uuid4().hex
+        admin_id = uuid4().hex
+        address = addresser.make_role_admins_address(role_id, admin_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.ROLES_ADMINS,
+            "The address created must be a Role Attributes address.")

--- a/addressing/rbac_addressing/__tests__/role_members.py
+++ b/addressing/rbac_addressing/__tests__/role_members.py
@@ -1,0 +1,84 @@
+# Copyright contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import unittest
+import logging
+from uuid import uuid4
+from rbac_addressing import addresser
+from rbac_addressing.addresser import AddressSpace
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestRoleMembersAddresser(unittest.TestCase):
+
+    def test_determine_role_member_addr(self):
+        """Tests that a specific role_id and member_id generates the
+        expected role member address, and thus is probably deterministic.
+        """
+
+        role_id = '99968acb8f1a48b3a4bc21e2cd252e67'
+        member_id = '966ab67317234df489adb4bc1f517b88'
+        expected_address = '9f444809326a1713a905b26359fc8d\
+a2817c1a5f67de6f464701f0c10042da345d2833'
+        address = addresser.make_role_members_address(role_id, member_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(address, expected_address,
+                         "The address is the one we expected it to be")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.ROLES_MEMBERS,
+            "The address created must be a Role Attributes address.")
+
+    def test_generated_role_member_addr(self):
+        """Tests the role member address creation function as well as the
+        address_is function.
+        """
+
+        role_id = uuid4().hex
+        member_id = uuid4().hex
+        address = addresser.make_role_members_address(role_id, member_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.ROLES_MEMBERS,
+            "The address created must be a Role Attributes address.")

--- a/addressing/rbac_addressing/__tests__/role_owners.py
+++ b/addressing/rbac_addressing/__tests__/role_owners.py
@@ -1,0 +1,84 @@
+# Copyright contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import unittest
+import logging
+from uuid import uuid4
+from rbac_addressing import addresser
+from rbac_addressing.addresser import AddressSpace
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestRoleOwnersAddresser(unittest.TestCase):
+
+    def test_determine_role_owner_addr(self):
+        """Tests that a specific role_id and owner_id generates the
+        expected role owner address, and thus is probably deterministic.
+        """
+
+        role_id = '99968acb8f1a48b3a4bc21e2cd252e67'
+        owner_id = '966ab67317234df489adb4bc1f517b88'
+        expected_address = '9f444809326a1713a905b26359fc8d\
+a2817c1a5f67de6f464701f0c10042da345d2893'
+        address = addresser.make_role_owners_address(role_id, owner_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(address, expected_address,
+                         "The address is the one we expected it to be")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.ROLES_OWNERS,
+            "The address created must be a Role Attributes address.")
+
+    def test_generated_role_owner_addr(self):
+        """Tests the role owner address creation function as well as the
+        address_is function.
+        """
+
+        role_id = uuid4().hex
+        owner_id = uuid4().hex
+        address = addresser.make_role_owners_address(role_id, owner_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.ROLES_OWNERS,
+            "The address created must be a Role Attributes address.")

--- a/addressing/rbac_addressing/__tests__/role_tasks.py
+++ b/addressing/rbac_addressing/__tests__/role_tasks.py
@@ -1,0 +1,84 @@
+# Copyright contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import unittest
+import logging
+from uuid import uuid4
+from rbac_addressing import addresser
+from rbac_addressing.addresser import AddressSpace
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestRoleTasksAddresser(unittest.TestCase):
+
+    def test_determine_role_task_addr(self):
+        """Tests that a specific role_id and task_id generates the
+        expected role task address, and thus is probably deterministic.
+        """
+
+        role_id = '99968acb8f1a48b3a4bc21e2cd252e67'
+        task_id = '966ab67317234df489adb4bc1f517b88'
+        expected_address = '9f444809326a1713a905b26359fc8d\
+a2817c1a5f67de6f464701f0c10042da345d28c5'
+        address = addresser.make_role_tasks_address(role_id, task_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(address, expected_address,
+                         "The address is the one we expected it to be")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.ROLES_TASKS,
+            "The address created must be a Role Attributes address.")
+
+    def test_generated_role_task_addr(self):
+        """Tests the role task address creation function as well as the
+        address_is function.
+        """
+
+        role_id = uuid4().hex
+        task_id = uuid4().hex
+        address = addresser.make_role_tasks_address(role_id, task_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.ROLES_TASKS,
+            "The address created must be a Role Attributes address.")

--- a/addressing/rbac_addressing/__tests__/sysadmin.py
+++ b/addressing/rbac_addressing/__tests__/sysadmin.py
@@ -1,0 +1,55 @@
+# Copyright contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import unittest
+import logging
+from rbac_addressing import addresser
+from rbac_addressing.addresser import AddressSpace
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestSysAdminAttributesAddresser(unittest.TestCase):
+
+    def test_determine_sysadmin_addr(self):
+        """Tests that a specific sysadmin_id generates the expected
+        sysadmin address, and thus is probably deterministic.
+        """
+
+        expected_address = '9f4448000000000000000000000000\
+0000000000000000000000000000000000000000'
+
+        address = addresser.make_sysadmin_attr_address()
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(address, expected_address,
+                         "The address is the one we expected it to be")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.SYSADMIN_ATTRIBUTES,
+            "The address created must be a SysAdmin Attributes address.")

--- a/addressing/rbac_addressing/__tests__/sysadmin_admins.py
+++ b/addressing/rbac_addressing/__tests__/sysadmin_admins.py
@@ -1,0 +1,83 @@
+# Copyright contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import unittest
+import logging
+from uuid import uuid4
+from rbac_addressing import addresser
+from rbac_addressing.addresser import AddressSpace
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestSysAdminAdminsAddresser(unittest.TestCase):
+
+    def test_det_sysadmin_admin_addr(self):
+        """Tests that a specific admin_id generates the expected
+        sysadmin admin address, and thus is probably deterministic.
+        """
+
+        admin_id = '966ab67317234df489adb4bc1f517b88'
+        expected_address = '9f4448000000000000000000000000\
+00000000000000000000000000000000000000f7'
+        address = addresser.make_sysadmin_admins_address(admin_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(address, expected_address,
+                         "The address is the one we expected it to be")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.SYSADMIN_ADMINS,
+            "The address created must be a SysAdmin Attributes address.")
+
+
+    def test_gen_sysadmin_admin_addr(self):
+        """Tests the sysadmin admin address creation function as well as the
+        address_is function.
+        """
+
+        admin_id = uuid4().hex
+        address = addresser.make_sysadmin_admins_address(admin_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.SYSADMIN_ADMINS,
+            "The address created must be a SysAdmin Attributes address.")

--- a/addressing/rbac_addressing/__tests__/sysadmin_members.py
+++ b/addressing/rbac_addressing/__tests__/sysadmin_members.py
@@ -1,0 +1,82 @@
+# Copyright contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import unittest
+import logging
+from uuid import uuid4
+from rbac_addressing import addresser
+from rbac_addressing.addresser import AddressSpace
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestSysAdminMembersAddresser(unittest.TestCase):
+
+    def test_det_sysadmin_member_addr(self):
+        """Tests that a specific member_id generates the expected
+        sysadmin member address, and thus is probably deterministic.
+        """
+
+        member_id = '966ab67317234df489adb4bc1f517b88'
+        expected_address = '9f4448000000000000000000000000\
+0000000000000000000000000000000000000083'
+        address = addresser.make_sysadmin_members_address(member_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(address, expected_address,
+                         "The address is the one we expected it to be")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.SYSADMIN_MEMBERS,
+            "The address created must be a SysAdmin Attributes address.")
+
+    def test_gen_sysadmin_member_addr(self):
+        """Tests the sysadmin member address creation function as well as the
+        address_is function.
+        """
+
+        member_id = uuid4().hex
+        address = addresser.make_sysadmin_members_address(member_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.SYSADMIN_MEMBERS,
+            "The address created must be a SysAdmin Attributes address.")

--- a/addressing/rbac_addressing/__tests__/sysadmin_owners.py
+++ b/addressing/rbac_addressing/__tests__/sysadmin_owners.py
@@ -1,0 +1,82 @@
+# Copyright contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import unittest
+import logging
+from uuid import uuid4
+from rbac_addressing import addresser
+from rbac_addressing.addresser import AddressSpace
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestSysAdminOwnersAddresser(unittest.TestCase):
+
+    def test_det_sysadmin_owner_addr(self):
+        """Tests that a specific owner_id generates the expected
+        sysadmin owner address, and thus is probably deterministic.
+        """
+
+        owner_id = '966ab67317234df489adb4bc1f517b88'
+        expected_address = '9f4448000000000000000000000000\
+00000000000000000000000000000000000000de'
+        address = addresser.make_sysadmin_owners_address(owner_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(address, expected_address,
+                         "The address is the one we expected it to be")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.SYSADMIN_OWNERS,
+            "The address created must be a SysAdmin Attributes address.")
+
+    def test_gen_sysadmin_owner_addr(self):
+        """Tests the sysadmin owner address creation function as well as the
+        address_is function.
+        """
+
+        owner_id = uuid4().hex
+        address = addresser.make_sysadmin_owners_address(owner_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.SYSADMIN_OWNERS,
+            "The address created must be a SysAdmin Attributes address.")

--- a/addressing/rbac_addressing/__tests__/task.py
+++ b/addressing/rbac_addressing/__tests__/task.py
@@ -1,0 +1,82 @@
+# Copyright contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import unittest
+import logging
+from uuid import uuid4
+from rbac_addressing import addresser
+from rbac_addressing.addresser import AddressSpace
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestTaskAttributesAddresser(unittest.TestCase):
+
+    def test_deterministic_task_address(self):
+        """Tests that a specific task_id generates the expected
+        task address, and thus is probably deterministic.
+        """
+
+        ident = '99968acb8f1a48b3a4bc21e2cd252e67'
+        expected_address = '9f44481e326a1713a905b26359fc8d\
+a2817c1a5f67de6f464701f0c10042da345d2800'
+        address = addresser.make_task_attributes_address(ident)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(address, expected_address,
+                         "The address is the one we expected it to be")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.TASKS_ATTRIBUTES,
+            "The address created must be a Task Attributes address.")
+
+    def test_generated_task_address(self):
+        """Tests the task address creation function as well as the
+        address_is function.
+        """
+
+        ident = uuid4().hex
+        address = addresser.make_task_attributes_address(ident)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.TASKS_ATTRIBUTES,
+            "The address created must be a Task Attributes address.")

--- a/addressing/rbac_addressing/__tests__/task_admins.py
+++ b/addressing/rbac_addressing/__tests__/task_admins.py
@@ -1,0 +1,85 @@
+# Copyright contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import unittest
+import logging
+from uuid import uuid4
+from rbac_addressing import addresser
+from rbac_addressing.addresser import AddressSpace
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestTaskAdminsAddresser(unittest.TestCase):
+
+    def test_determine_task_admin_addr(self):
+        """Tests that a specific task_id and admin_id generates the
+        expected task admin address, and thus is probably deterministic.
+        """
+
+        task_id = '99968acb8f1a48b3a4bc21e2cd252e67'
+        admin_id = '966ab67317234df489adb4bc1f517b88'
+        expected_address = '9f44481e326a1713a905b26359fc8d\
+a2817c1a5f67de6f464701f0c10042da345d2848'
+        address = addresser.make_task_admins_address(task_id, admin_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(address, expected_address,
+                         "The address is the one we expected it to be")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.TASKS_ADMINS,
+            "The address created must be a Task Attributes address.")
+
+
+    def test_generated_task_admin_addr(self):
+        """Tests the task admin address creation function as well as the
+        address_is function.
+        """
+
+        task_id = uuid4().hex
+        admin_id = uuid4().hex
+        address = addresser.make_task_admins_address(task_id, admin_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.TASKS_ADMINS,
+            "The address created must be a Task Attributes address.")

--- a/addressing/rbac_addressing/__tests__/task_owners.py
+++ b/addressing/rbac_addressing/__tests__/task_owners.py
@@ -1,0 +1,85 @@
+# Copyright contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import unittest
+import logging
+from uuid import uuid4
+from rbac_addressing import addresser
+from rbac_addressing.addresser import AddressSpace
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestTaskOwnersAddresser(unittest.TestCase):
+
+    def test_determine_task_owner_addr(self):
+        """Tests that a specific task_id and owner_id generates the
+        expected task owner address, and thus is probably deterministic.
+        """
+
+        task_id = '99968acb8f1a48b3a4bc21e2cd252e67'
+        owner_id = '966ab67317234df489adb4bc1f517b88'
+        expected_address = '9f44481e326a1713a905b26359fc8d\
+a2817c1a5f67de6f464701f0c10042da345d2808'
+        address = addresser.make_task_owners_address(task_id, owner_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(address, expected_address,
+                         "The address is the one we expected it to be")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.TASKS_OWNERS,
+            "The address created must be a Task Attributes address.")
+
+
+    def test_generated_task_owner_addr(self):
+        """Tests the task owner address creation function as well as the
+        address_is function.
+        """
+
+        task_id = uuid4().hex
+        owner_id = uuid4().hex
+        address = addresser.make_task_owners_address(task_id, owner_id)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.TASKS_OWNERS,
+            "The address created must be a Task Attributes address.")

--- a/addressing/rbac_addressing/__tests__/test_addresser.py
+++ b/addressing/rbac_addressing/__tests__/test_addresser.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Intel Corporation
+# Copyright contributors to Hyperledger Sawtooth
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,12 +13,14 @@
 # limitations under the License.
 # -----------------------------------------------------------------------------
 
+import logging
 import unittest
 from uuid import uuid4
 
 from rbac_addressing import addresser
 from rbac_addressing.addresser import AddressSpace
 
+LOGGER = logging.getLogger(__name__)
 
 class TestAddresser(unittest.TestCase):
 

--- a/addressing/rbac_addressing/__tests__/user.py
+++ b/addressing/rbac_addressing/__tests__/user.py
@@ -1,0 +1,83 @@
+# Copyright contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import unittest
+import logging
+from uuid import uuid4
+from rbac_addressing import addresser
+from rbac_addressing.addresser import AddressSpace
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestUserAddresser(unittest.TestCase):
+
+    def test_deterministic_user_address(self):
+        """Tests that a specific user_id generates the expected
+        user address, and thus is probably deterministic.
+        """
+
+        ident = '966ab67317234df489adb4bc1f517b88'
+        expected_address = '9f444847e7570f3f6f7d2c1635f6de\
+eabc1f4d78d9d42b64b70e1819f244138c1e38d6'
+        address = addresser.make_user_address(ident)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(address, expected_address,
+                         "The address is the one we expected it to be")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.USER,
+            "The User address created must be found to be a User address.")
+
+
+    def test_generated_user_address(self):
+        """Tests the Users address creation function as well as the
+        address_is function.
+        """
+
+        ident = uuid4().hex
+        address = addresser.make_user_address(ident)
+
+        self.assertEqual(len(address), addresser.ADDRESS_LENGTH,
+                         "The address is 70 characters")
+
+        self.assertTrue(addresser.is_address(address),
+                        "The address is 70 character hexidecimal")
+
+        self.assertTrue(addresser.namespace_ok(address),
+                        "The address has correct namespace prefix")
+
+        self.assertTrue(
+            addresser.is_family_address(address),
+            "The address is 70 character hexidecimal with family prefix")
+
+        self.assertEqual(
+            addresser.address_is(address),
+            AddressSpace.USER,
+            "The address created must be found to be a User address.")

--- a/addressing/rbac_addressing/addresser.py
+++ b/addressing/rbac_addressing/addresser.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Intel Corporation
+# Copyright contributors to Hyperledger Sawtooth
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 # -----------------------------------------------------------------------------
 
+import re
 import enum
 from hashlib import sha512
 
@@ -75,7 +76,10 @@ class TaskRelationshipNamespace(enum.IntEnum):
 
 FAMILY_NAME = 'rbac'
 NS = sha512(FAMILY_NAME.encode()).hexdigest()[:6]
-
+FAMILY_PREFIX = '9f4448'
+ADDRESS_LENGTH = 70
+ADDRESS_PATTERN = re.compile(r'^[0-9a-f]{70}$')
+FAMILY_PATTERN = re.compile(r'^9f4448[0-9a-f]{64}$')
 
 @enum.unique
 class AddressSpace(enum.Enum):
@@ -106,6 +110,32 @@ def namespace_ok(address):
     return address[:len(NS)] == NS
 
 
+def is_address(address):
+    """Determines the address is a valid Sawtooth address
+       (a 70 character hexadecimal string)
+
+    Args:
+        address (str): A 70 character state address.
+
+    Returns: Boolean
+
+    """
+    return bool(ADDRESS_PATTERN.match(address))
+
+
+def is_family_address(address):
+    """Determines the address is a valid Sawtooth address
+       with the correct family prefix.
+
+    Args:
+        address (str): A 70 character state address.
+
+    Returns: Boolean
+
+    """
+    return bool(FAMILY_PATTERN.match(address))
+
+
 def address_is(address):
     """Determines the type of object stored at the address.
 
@@ -115,7 +145,7 @@ def address_is(address):
     Returns: AddressSpace enum identifying the part of state.
 
     """
-    if not namespace_ok(address):
+    if not FAMILY_PATTERN.match(address):
         raise ValueError("Address %s isn't part of the %s namespace",
                          address, FAMILY_NAME)
 

--- a/bin/build
+++ b/bin/build
@@ -55,7 +55,7 @@ do
             ;;
         t)
             info "Running tests"
-            $TOP_DIR/bin/run_tests_ubuntu
+            pytest
             ;;
         l)
             info "Running lint"
@@ -73,7 +73,7 @@ do
             info "Running lint"
             docker run --rm -v $(pwd):/project/tmobile-rbac rbac-test-env bin/run_lint
             info "Running tests"
-            $TOP_DIR/bin/run_tests_ubuntu
+            pytest
             info "Running integration tests"
             $TOP_DIR/bin/run_docker_test $TOP_DIR/integration_tests/blockchain/docker-compose.yaml
             ;;

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+log_cli=true
+log_level=NOTSET
+log_format = %(asctime)s %(levelname)s %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S
+python_files = __tests__/*.py


### PR DESCRIPTION
This increases test coverage of the addresser, and breaks the tests out into pieces for maintainability and self-documentation.

Run using ```pytest```

It makes one small code change to validate the entire address string via regular expression instead of just checking the prefix of the string.

It does not attempt comprehensive test coverage of the addresser, but enough to facilitate future refactoring of the addressing code and addressing scheme.

Resolves Issue #141 