### PR TITLE
Update shell to support python commands

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,16 +17,18 @@ version: "3"
 
 services:
   shell:
+    build:
+      context: .
+      dockerfile: ./shell/Dockerfile
     image: hyperledger/sawtooth-shell:1.0
     container_name: rbac-shell
     depends_on:
       - rest-api
-    entrypoint: |
-      bash -c "
-        sawtooth keygen &&
-        tail -f /dev/null
-      \"\""
-
+    volumes:
+      - ".:/project/tmobile-rbac"
+    environment:
+      PYTHONPATH: /project/tmobile-rbac/addressing:/project/tmobile-rbac/transaction_creation
+  
   rbac-server:
     build:
       context: .

--- a/docker-dev.yaml
+++ b/docker-dev.yaml
@@ -25,9 +25,6 @@
 
 version: "3"
 services:
-  shell:
-    volumes:
-      - ".:/project/tmobile-rbac"
 
   rbac-server:
     build:

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -1,0 +1,40 @@
+# Copyright contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+FROM hyperledger/sawtooth-validator:1.0
+
+RUN apt-get update && \
+    apt-get install -y --allow-unauthenticated -q \
+        locales \
+        python3-grpcio-tools=1.1.3-1 \
+        python3-pip \
+        python3-sawtooth-sdk \
+        python3-sawtooth-rest-api
+
+RUN locale-gen en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+RUN pip3 install \
+    pycodestyle \
+    pylint \
+    itsdangerous \
+    rethinkdb \
+    sanic==0.7.0 \
+    pycrypto \
+    pytest
+
+WORKDIR /project/tmobile-rbac
+
+CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
You can bash into the shell ```docker exec -it rbac-shell bash```
and run python code and tests. e.g. ```pytest```

Issue #145 