### PR TITLE
Adding requirements.txt to manage global developer python dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,11 @@ Please ensure the unit and integration tests run successfully. Refer to the
 Testing section in the [README.md](README.md) on how to run these
 tests.
 
-Please ensure that lint passes by running ‘./bin/run_lint’. The command should
-produce no output if there are no lint errors.
+Please ensure that lint passes by running `./bin/run_lint`. The command should
+produce no output if there are no lint errors. The linter requires all Python 
+dependencies be installed locally (if not it'll throw import-errors). Install
+dependencies locally by running `pip3 install -r requirements.dev.txt` from the 
+root project directory.
 
 Pull Request Guidelines
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,15 @@
+itsdangerous==0.24
+dredd_hooks==0.2.0
+rethinkdb==2.3.0.post6
+sawtooth_sdk==1.0.5
+sawtooth_signing==1.0.5
+sanic==0.8.3
+pycrypto==2.6.1
+protobuf==3.6.1
+pyzmq==17.1.2
+black==18.9b0
+pylint==2.1.1
+astroid==2.0.4
+clang==6.0
+pycodestyle==2.4.0
+pipreqs==0.4.9


### PR DESCRIPTION
Added a requirements.txt for developers to install python dependencies (linter will return import errors if all dependencies are not installed locally). I need create tasks to:
- add instructions to readme.md on using requirements.txt
- add requirements.txt for each container directory
- add a script to bin for updating all requirements.txt files

Run `pip3 install -r requirements.txt` in the root project directory to install development dependencies for the project.