### PR TITLE
Implemented deployment script for master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,39 @@ jobs:
         - npm install
       script:
         - npm test
+    
+    # The deploy stage will deploy the master branch to a remote server once a 
+    #   merge occurs on the branch. Steps required to deploy to remote server:
+    #
+    #     1. Generate an SSH keypair to SSH into remote server
+    #
+    #     2. Clone Sawtooth NEXT Directory repo into your remote server and configure the 
+    #        cloned repo to allow pushes:
+    #            $ git clone https://github.com/hyperledger/sawtooth-next-directory.git
+    #            $ cd sawtooth-next-directory
+    #            $ git config --local receive.denyCurrentBranch updateInstead
+    #              
+    #     3. Run 'travis encrypt-file id_rsa' command to encrypt the SSH private key 
+    #        (change id_rsa to the name of your private key). Add the output of the 
+    #        command to the before_install stage and replace id_rsa.enc with the encrypted 
+    #        private key to the .travis folder.
+    #        More information can be found here: https://docs.travis-ci.com/user/encrypting-files/
+    #
+    #     4. Add the following env variables into Travis Repo Settings to properly deploy:
+    #          - IP: remote server's IP
+    #          - DEPLOY_DIR: location of cloned repo on remote server
+    #          - DEPLOY_USER: username of the user on the remote server
+    #
+    - stage: deploy
+      if: branch = master AND type = push AND env(IP)
+      language: generic
+      before_install:
+        # Decrypt the encrypted private key file named 'id_rsa.enc' and save the decrypted key for
+        #   use to SSH into remote server. This command is outputted from the 'travis encrypt-file'
+        #   command.
+        - openssl aes-256-cbc -K $encrypted_[hex string]_key -iv $encrypted_[hex string]_iv 
+          -in .travis/id_rsa.enc -out .travis/id_rsa -d
+        - ssh-keyscan -H $IP >> ~/.ssh/known_hosts
+        - chmod +x ./.travis/deploy.sh
+      after_success:
+        - ./.travis/deploy.sh

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Start ssh-agent cache and adds decrypted private key
+eval "$(ssh-agent -s)"
+chmod 600 .travis/id_rsa
+ssh-add .travis/id_rsa
+
+# Add a remote called deploy and pushes the master branch to the remote
+git remote add deploy ssh://$DEPLOY_USER@$IP/~/$DEPLOY_DIR
+git push deploy master
+
+# SSH into the remote server and start NEXT Directory Platform
+ssh $DEPLOY_USER@$IP <<EOF
+    cd $DEPLOY_DIR
+    sudo docker-compose down &
+    export PID=$!
+    wait $PID
+    sudo docker-compose -f docker-compose.yaml -f docker-persist.yaml up -d --build
+EOF


### PR DESCRIPTION
Implemented deployment script of master branch to a remote server.
Once a PR gets merged into master and all tests in travis passes,
travis will SSH into the remote server and push the new changes
from the master branch into the remote server. The deploy.sh script
run docker-compose down to shutdown the running containers on the
remote server. After a succesful shutdown, the script will spin up
the NEXT containers in persistent data mode.

Relates to Issue #103 

Signed-off-by: Michael Nguyen <michael.nguyen79@t-mobile.com>