### PR TITLE
Updated deploy.sh to reset data

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -9,7 +9,19 @@ ssh-add .travis/id_rsa
 git remote add deploy ssh://$DEPLOY_USER@$IP/~/$DEPLOY_DIR
 git push deploy master
 
-# SSH into the remote server and start NEXT Directory Platform
+# If the commit message contains the phrase 'RESET_NEXT_STORAGE', this deployment will 
+# reset the data on the remote server back to genesis. Volumes might be named differently,
+# refer to documentation in ~/docker-persist.yaml for additional information.
+if [[ $TRAVIS_COMMIT_MESSAGE = *"RESET_NEXT_STORAGE"* ]] ; then
+    RESTART_CONTAINER="sudo docker volume rm sawtooth-next-directory_chain
+    sudo docker volume rm sawtooth-next-directory_keys
+    sudo docker volume rm sawtooth-next-directory_db
+    "
+fi
+
+RESTART_CONTAINER+="sudo docker-compose -f docker-compose.yaml -f docker-persist.yaml up -d --build"
+
+# SSH into the remote server and start NEXT Directory Platform 
 ssh $DEPLOY_USER@$IP <<EOF
     cd $DEPLOY_DIR
     sudo docker-compose down &


### PR DESCRIPTION
Deploy.sh now resets the data on the remote server back to genesis.
To have the script reset the data, include the phrase
"RESET_NEXT_STORAGE" (without the quotes) in the commit message.
If the phrase is not in the commit message, the script will shutdown
and restart the containers maintaining the persistent data.

Resolves #177 

Signed-off-by: Michael Nguyen <michael.nguyen79@t-mobile.com>