### PR TITLE
Configures travis env for this project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ jobs:
     - stage: backend
       language: python
       python:
-        - "3.6"
+        - "3.5.2"
       script:
         - pytest --ignore=tests
-
+      env:
+        PYTHONPATH: /project/tmobile-rbac/addressing:/project/tmobile-rbac/transaction_creation
     - stage: frontend
       language: node_js
       node_js:


### PR DESCRIPTION
Set the Travis environment by Python 3.5.2 (required by Sawtooth)
Tells Python where to look for the source (PYTHONPATH)