### PR TITLE
Proposing adding Adam G. as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,6 +2,7 @@
 | --- | --- | --- |
 | Boyd Johnson | boydjohnson | boydjohnson |
 | Zac Delventhal | delventhalz | zac |
+| Adam Gering | adamgering | adamgering |
 | Darian Plumb | dplumb94 | dplumb |
 | Michael Nguyen | mtn217 | mtn206 |
 | Chris Spanton | chrisspanton | ChrisSpanton |


### PR DESCRIPTION
Discussions were had, and it was agreed upon to have Adam join as
a maintainer in lieu of Zac Delventhal.

Signed-off-by: Michael Nguyen <michael.nguyen79@t-mobile.com>