### PR TITLE
Fix license headers to conform to Apache 2.0

### DIFF
--- a/rbac/processor/role/role_owners.py
+++ b/rbac/processor/role/role_owners.py
@@ -1,3 +1,7 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0

--- a/tests/transactions/common.py
+++ b/tests/transactions/common.py
@@ -1,3 +1,18 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
 import re
 
 PRIVATE_KEY_LENGTH = 64


### PR DESCRIPTION
Correct license header problems identified in latest scan
(https://jira.hyperledger.org/browse/STL-398)
