### PR TITLE
Use SSL cert for Azure OAuth2 token generation

### DIFF
--- a/bin/rbac-providers-azure
+++ b/bin/rbac-providers-azure
@@ -22,8 +22,8 @@ import sys
 TOP_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, TOP_DIR)
 
-from rbac.providers.azure.main import users
+from rbac.providers.azure.main import fetch_users
 
 if __name__ == "__main__":
-    users = users()
+    users = fetch_users()
     print(users)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
     image: rbac-provider-azure-production:${ISOLATION_ID-latest}
     environment:
       - CLIENT_ID=${CLIENT_ID}
-      - CLIENT_SECRET=${CLIENT_SECRET}
+      - CLIENT_ASSERTION=${CLIENT_ASSERTION}
       - TENANT_ID=${TENANT_ID}
     command: ./bin/rbac-providers-azure
 

--- a/rbac/providers/azure/aad_auth.py
+++ b/rbac/providers/azure/aad_auth.py
@@ -18,10 +18,13 @@ import requests
 import datetime as dt
 
 CLIENT_ID = os.environ.get('CLIENT_ID')
-CLIENT_SECRET = os.environ.get('CLIENT_SECRET')
+CLIENT_ASSERTION = os.environ.get('CLIENT_ASSERTION')
 TENANT_ID = os.environ.get('TENANT_ID')
 AAD_AUTH_URL = 'https://login.microsoftonline.com/{}'.format(TENANT_ID)
 TOKEN_ENDPOINT = '/oauth2/v2.0/token'
+GRANT_TYPE = 'client_credentials'
+CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+SCOPE = 'https://graph.microsoft.com/.default'
 
 
 class AadAuth:
@@ -35,10 +38,11 @@ class AadAuth:
 
     def get_token(self):
         """Get an access Token for Azure Active Directory Graph API."""
-        data = {'client_id': CLIENT_ID,
-                'scope': 'https://graph.microsoft.com/.default',
-                'client_secret': CLIENT_SECRET,
-                'grant_type': 'client_credentials'}
+        data = {'grant_type': GRANT_TYPE,
+                'client_id': CLIENT_ID,
+                'client_assertion_type': CLIENT_ASSERTION_TYPE,
+                'client_assertion': CLIENT_ASSERTION,
+                'scope': SCOPE}
         response = requests.post(url=AAD_AUTH_URL + TOKEN_ENDPOINT, data=data)
         return response
 
@@ -57,4 +61,6 @@ class AadAuth:
             response = self.get_token()
             self.token_creation_timestamp = dt.datetime.now()
             self.graph_token = response.json()['access_token']
-        return {'Authorization': self.graph_token, 'Accept': 'application/json'}
+        return {'Authorization': self.graph_token, 
+                'Accept': 'application/json', 
+                'Host': 'graph.microsoft.com'}


### PR DESCRIPTION
Switch to using SSL cert to get an oauth2 token for the azure ad sync daemon.

Signed-off-by: jbobo <j.ned@bobonana.me>