### PR TITLE
Don't ignore protobufs on docker copy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,5 @@
 **/public/dist
 
-# Protobuf
-**/protobuf/
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Don't ignore protobufs on docker copy.

Protobufs are now prebuilt and should be copied rather than generated every build.
