### PR TITLE
Add user manager proposal messages

### DIFF
--- a/rbac/common/manager/base_message.py
+++ b/rbac/common/manager/base_message.py
@@ -1,0 +1,172 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import logging
+from rbac.common import protobuf
+from rbac.common.crypto.keys import Key
+from rbac.common.sawtooth.batcher import Batcher
+from rbac.common.sawtooth.state_client import StateClient
+from rbac.common.sawtooth.client_sync import ClientSync
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class BaseMessage:
+    def __init__(self):
+        """Objects and methods shared across message libraries"""
+        self.batch = Batcher()
+        self.client = ClientSync()
+        self.state = StateClient()
+
+    def getattr(self, item, attribute):
+        """A version of getattr that will return None if attributes
+        is not found on the item"""
+        if hasattr(item, attribute):
+            return getattr(item, attribute)
+        return None
+
+    @property
+    def name(self):
+        raise NotImplementedError("Class must implement this property")
+
+    @property
+    def names(self):
+        return self.name + "s"
+
+    @property
+    def message_type(self):
+        raise NotImplementedError("Class must implement this method")
+
+    @property
+    def message_proto(self):
+        raise NotImplementedError("Class must implement this method")
+
+    @property
+    def container_proto(self):
+        raise NotImplementedError("Class must implement this method")
+
+    @property
+    def state_proto(self):
+        raise NotImplementedError("Class must implement this method")
+
+    def address(self, object_id, target_id):
+        raise NotImplementedError("Class must implement this method")
+
+    def make(self, object_id):
+        raise NotImplementedError("Class must implement this method")
+
+    def make_addresses(self, message):
+        raise NotImplementedError("Class must implement this method")
+
+    def make_payload(self, message):
+        """Make a payload for the given message type"""
+        if not isinstance(message, self.message_proto):
+            raise TypeError("Expected message to be {}".format(self.message_proto))
+
+        message_type = self.message_type
+        inputs, outputs = self.make_addresses(message=message)
+        return self.batch.make_payload(
+            message=message, message_type=message_type, inputs=inputs, outputs=outputs
+        )
+
+    def create(self, signer_keypair, message, object_id=None, target_id=None):
+        """Send a message to the blockchain"""
+        if not isinstance(signer_keypair, Key):
+            raise TypeError("Expected signer_keypair to be a Key")
+
+        return self.send(
+            signer_keypair=signer_keypair,
+            payload=self.make_payload(message=message),
+            object_id=object_id,
+            target_id=target_id,
+        )
+
+    def send(self, signer_keypair, payload, object_id=None, target_id=None):
+        """Sends a payload to the transaction processor"""
+        if not isinstance(signer_keypair, Key):
+            raise TypeError("Expected signer_keypair to be a Key")
+        if not isinstance(payload, protobuf.rbac_payload_pb2.RBACPayload):
+            raise TypeError("Expected payload to be an RBACPayload")
+
+        _, _, batch_list, _ = self.batch.make(
+            payload=payload, signer_keypair=signer_keypair
+        )
+        got = None
+
+        status = self.client.send_batches_get_status(batch_list=batch_list)
+
+        if object_id is not None:
+            got = self.get(object_id=object_id, target_id=target_id)
+
+        return got, status
+
+    def _find_in_container(self, container, address, object_id, target_id=None):
+        items = list(getattr(container, self.names))
+        if len(items) == 0:
+            return None
+        elif len(items) > 1:
+            LOGGER.warning(
+                "%s container for %s target %s has more than one record at address %s",
+                self.name,
+                object_id,
+                target_id,
+                address,
+            )
+        for item in items:
+            if (
+                self.getattr(item, "object_id") == object_id
+                and self.getattr(item, "target_id") == target_id
+            ):
+                return item
+            if self.getattr(item, self.name + "_id") == object_id and target_id is None:
+                return item
+        LOGGER.warning(
+            "%s not found in container for %s target %s at address %s",
+            self.name,
+            object_id,
+            target_id,
+            address,
+        )
+        return None
+
+    def get(self, object_id, target_id=None):
+        """Gets an address from the blockchain from the API"""
+        address = self.address(object_id=object_id, target_id=target_id)
+        container = self.container_proto()
+        container.ParseFromString(self.client.get_address(address=address))
+        return self._find_in_container(
+            container=container,
+            address=address,
+            object_id=object_id,
+            target_id=target_id,
+        )
+
+    def get_state(self, state, object_id, target_id=None):
+        """Gets an address from the blockchain state from the state object"""
+        address = self.address(object_id=object_id, target_id=target_id)
+        container = self.container_proto()
+
+        results = self.state.get_address(state=state, address=address)
+        if len(list(results)) == 0:
+            return None
+
+        container.ParseFromString(results[0].data)
+        return self._find_in_container(
+            container=container,
+            address=address,
+            object_id=object_id,
+            target_id=target_id,
+        )

--- a/rbac/common/sawtooth/rbac_payload.proto
+++ b/rbac/common/sawtooth/rbac_payload.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Intel Corporation
+// Copyright 2018 Contributors to Hyperledger Sawtooth
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rbac/common/sawtooth/state_client.py
+++ b/rbac/common/sawtooth/state_client.py
@@ -1,0 +1,41 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import logging
+
+from sawtooth_sdk.messaging.future import FutureTimeoutError
+from sawtooth_sdk.processor.exceptions import InternalError
+
+TIMEOUT_SECONDS = 2
+ERROR_MESSAGE_TIMEOUT = "Timeout after %s seconds during get from state"
+
+LOGGER = logging.getLogger(__name__)
+
+
+class StateClient:
+    def get_address(self, state, address):
+        try:
+            return state.get_state(addresses=[address], timeout=TIMEOUT_SECONDS)
+        except FutureTimeoutError:
+            raise InternalError(ERROR_MESSAGE_TIMEOUT, TIMEOUT_SECONDS)
+
+    def set_address(self, state, address, container):
+        try:
+            return state.set_state(
+                entries={address: container.SerializeToString()},
+                timeout=TIMEOUT_SECONDS,
+            )
+        except FutureTimeoutError:
+            raise InternalError(ERROR_MESSAGE_TIMEOUT, TIMEOUT_SECONDS)

--- a/rbac/common/user/confirm_manager.py
+++ b/rbac/common/user/confirm_manager.py
@@ -1,0 +1,77 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import logging
+from rbac.addressing import addresser
+from rbac.common import protobuf
+from rbac.common.manager.base_message import BaseMessage
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ConfirmUpdateUserManager(BaseMessage):
+    def __init__(self):
+        BaseMessage.__init__(self)
+
+    @property
+    def name(self):
+        return "proposal"
+
+    @property
+    def message_type(self):
+        return protobuf.rbac_payload_pb2.RBACPayload.CONFIRM_UPDATE_USER_MANAGER
+
+    @property
+    def message_proto(self):
+        return protobuf.user_transaction_pb2.ConfirmUpdateUserManager
+
+    @property
+    def container_proto(self):
+        return protobuf.proposal_state_pb2.ProposalsContainer
+
+    @property
+    def state_proto(self):
+        return protobuf.proposal_state_pb2.ProposalsContainer
+
+    def address(self, object_id, target_id):
+        """Make the blockchain address for the given message"""
+        return addresser.make_proposal_address(
+            object_id=object_id, related_id=target_id
+        )
+
+    # pylint: disable=arguments-differ, not-callable
+    def make(self, proposal_id, user_id, manager_id, reason=None):
+        """Make the message"""
+        return self.message_proto(
+            proposal_id=proposal_id,
+            user_id=user_id,
+            manager_id=manager_id,
+            reason=reason,
+        )
+
+    def make_addresses(self, message):
+        """Makes the approporiate inputs & output addresses for the message"""
+        if not isinstance(message, self.message_proto):
+            raise TypeError("Expected message to be {}".format(self.message_proto))
+
+        proposal_address = addresser.make_proposal_address(
+            object_id=message.user_id, related_id=message.manager_id
+        )
+        user_address = addresser.make_user_address(user_id=message.user_id)
+
+        inputs = [proposal_address, user_address]
+        outputs = inputs
+
+        return inputs, outputs

--- a/rbac/common/user/create_user.py
+++ b/rbac/common/user/create_user.py
@@ -1,0 +1,148 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import logging
+from rbac.common.crypto.keys import Key
+from rbac.common.user.user_address import make_user_address
+from rbac.common import protobuf
+from rbac.common.manager.base_message import BaseMessage
+from sawtooth_sdk.processor.exceptions import InvalidTransaction
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CreateUser(BaseMessage):
+    def __init__(self):
+        BaseMessage.__init__(self)
+
+    @property
+    def name(self):
+        return "user"
+
+    @property
+    def message_type(self):
+        return protobuf.rbac_payload_pb2.RBACPayload.CREATE_USER
+
+    @property
+    def message_proto(self):
+        return protobuf.user_transaction_pb2.CreateUser
+
+    @property
+    def container_proto(self):
+        return protobuf.user_state_pb2.UserContainer
+
+    @property
+    def state_proto(self):
+        return protobuf.user_state_pb2.User
+
+    def address(self, object_id, target_id=None):
+        """Make an address for the given user_id"""
+        return make_user_address(object_id)
+
+    # pylint: disable=arguments-differ, not-callable
+    def make(
+        self, user_id, name, user_name=None, email=None, metadata=None, manager_id=None
+    ):
+        """Makes a CreateUser message"""
+        return self.message_proto(
+            user_id=user_id, name=name, metadata=metadata, manager_id=manager_id
+        )
+
+    def make_with_key(
+        self,
+        name,
+        user_id=None,
+        user_name=None,
+        email=None,
+        metadata=None,
+        manager_id=None,
+    ):
+        """Makes a CreateUser message with a new keypair"""
+        keypair = Key()
+        if user_id is None:
+            user_id = keypair.public_key
+
+        message = self.make(
+            user_id=user_id,
+            name=name,
+            user_name=user_name,
+            email=email,
+            metadata=metadata,
+            manager_id=manager_id,
+        )
+        return message, keypair
+
+    def make_addresses(self, message):
+        """Makes the approporiate inputs & output addresses for the message type"""
+        if not isinstance(message, self.message_proto):
+            raise TypeError("Expected message to be {}".format(self.message_proto))
+
+        user_address = self.address(object_id=message.user_id)
+        if message.manager_id:
+            manager_address = self.address(object_id=message.manager_id)
+
+        if message.manager_id:
+            inputs = [user_address, manager_address]
+        else:
+            inputs = [user_address]
+
+        outputs = inputs
+        return inputs, outputs
+
+    def new_state(self, state, message, object_id, target_id=None):
+        """Creates a new address in the blockchain state"""
+        address = self.address(object_id=object_id, target_id=target_id)
+        container = self.container_proto()
+        item = self.state_proto(
+            user_id=message.user_id,
+            name=message.name,
+            manager_id=message.manager_id,
+            metadata=message.metadata,
+        )
+        container.users.extend([item])
+        self.state.set_address(state=state, address=address, container=container)
+
+    def apply(self, state, payload, header):
+        """Handles a message in the transaction processor"""
+        message = self.message_proto()
+        message.ParseFromString(payload.content)
+
+        if not (
+            message.user_id == header.signer_public_key
+            or header.signer_public_key == message.manager_id
+        ):
+            raise InvalidTransaction(
+                "The public key {} that signed this CreateUser txn "
+                "does not belong to the user or their manager.".format(
+                    header.signer_public_key
+                )
+            )
+
+        if len(message.name) < 5:
+            raise InvalidTransaction(
+                "CreateUser txn with name {} is invalid. Users "
+                "must have names longer than 4 characters.".format(message.name)
+            )
+
+        check_user = self.get_state(state=state, object_id=message.user_id)
+        if check_user is not None:
+            raise InvalidTransaction("User already exists")
+
+        if message.manager_id:
+            check_manager = self.get_state(state=state, object_id=message.manager_id)
+            if check_manager is None:
+                raise InvalidTransaction("Manager is not in state")
+
+        self.new_state(state=state, message=message, object_id=message.user_id)

--- a/rbac/common/user/manager.py
+++ b/rbac/common/user/manager.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 # -----------------------------------------------------------------------------
 
-import logging
-from rbac.common.user.create_user import CreateUser
-from rbac.common.user.manager import Manager
-
-LOGGER = logging.getLogger(__name__)
+from rbac.common.user.propose_manager import ProposeUpdateUserManager
+from rbac.common.user.confirm_manager import ConfirmUpdateUserManager
+from rbac.common.user.reject_manager import RejectUpdateUserManager
 
 
-class UserManager(CreateUser):
+class Manager:
     def __init__(self):
-        CreateUser.__init__(self)
-        self.manager = Manager()
+        self.propose = ProposeUpdateUserManager()
+        self.confirm = ConfirmUpdateUserManager()
+        self.reject = RejectUpdateUserManager()

--- a/rbac/common/user/propose_manager.py
+++ b/rbac/common/user/propose_manager.py
@@ -1,0 +1,80 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import logging
+from uuid import uuid4
+from rbac.addressing import addresser
+from rbac.common import protobuf
+from rbac.common.manager.base_message import BaseMessage
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ProposeUpdateUserManager(BaseMessage):
+    def __init__(self):
+        BaseMessage.__init__(self)
+
+    @property
+    def name(self):
+        return "proposal"
+
+    @property
+    def message_type(self):
+        return protobuf.rbac_payload_pb2.RBACPayload.PROPOSE_UPDATE_USER_MANAGER
+
+    @property
+    def message_proto(self):
+        return protobuf.user_transaction_pb2.ProposeUpdateUserManager
+
+    @property
+    def container_proto(self):
+        return protobuf.proposal_state_pb2.ProposalsContainer
+
+    @property
+    def state_proto(self):
+        return protobuf.proposal_state_pb2.ProposalsContainer
+
+    def address(self, object_id, target_id):
+        """Make the blockchain address for the given message"""
+        return addresser.make_proposal_address(
+            object_id=object_id, related_id=target_id
+        )
+
+    # pylint: disable=arguments-differ, not-callable
+    def make(self, user_id, new_manager_id, reason=None, metadata=None):
+        """Make the message"""
+        return self.message_proto(
+            proposal_id=uuid4().hex,
+            user_id=user_id,
+            new_manager_id=new_manager_id,
+            reason=reason,
+            metadata=metadata,
+        )
+
+    def make_addresses(self, message):
+        """Makes the approporiate inputs & output addresses for the message"""
+        if not isinstance(message, self.message_proto):
+            raise TypeError("Expected message to be {}".format(self.message_proto))
+
+        user_address = addresser.make_user_address(user_id=message.user_id)
+        manager_address = addresser.make_user_address(user_id=message.new_manager_id)
+        proposal_address = addresser.make_proposal_address(
+            object_id=message.user_id, related_id=message.new_manager_id
+        )
+
+        inputs = [user_address, manager_address, proposal_address]
+        outputs = [proposal_address]
+
+        return inputs, outputs

--- a/rbac/common/user/reject_manager.py
+++ b/rbac/common/user/reject_manager.py
@@ -1,0 +1,76 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import logging
+from rbac.addressing import addresser
+from rbac.common import protobuf
+from rbac.common.manager.base_message import BaseMessage
+
+LOGGER = logging.getLogger(__name__)
+
+
+class RejectUpdateUserManager(BaseMessage):
+    def __init__(self):
+        BaseMessage.__init__(self)
+
+    @property
+    def name(self):
+        return "proposal"
+
+    @property
+    def message_type(self):
+        return protobuf.rbac_payload_pb2.RBACPayload.REJECT_UPDATE_USER_MANAGER
+
+    @property
+    def message_proto(self):
+        return protobuf.user_transaction_pb2.RejectUpdateUserManager
+
+    @property
+    def container_proto(self):
+        return protobuf.proposal_state_pb2.ProposalsContainer
+
+    @property
+    def state_proto(self):
+        return protobuf.proposal_state_pb2.ProposalsContainer
+
+    def address(self, object_id, target_id):
+        """Make the blockchain address for the given message"""
+        return addresser.make_proposal_address(
+            object_id=object_id, related_id=target_id
+        )
+
+    # pylint: disable=arguments-differ, not-callable
+    def make(self, proposal_id, user_id, manager_id, reason=None):
+        """Make the message"""
+        return self.message_proto(
+            proposal_id=proposal_id,
+            user_id=user_id,
+            manager_id=manager_id,
+            reason=reason,
+        )
+
+    def make_addresses(self, message):
+        """Makes the approporiate inputs & output addresses for the message"""
+        if not isinstance(message, self.message_proto):
+            raise TypeError("Expected message to be {}".format(self.message_proto))
+
+        proposal_address = addresser.make_proposal_address(
+            object_id=message.user_id, related_id=message.manager_id
+        )
+
+        inputs = [proposal_address]
+        outputs = [proposal_address]
+
+        return inputs, outputs

--- a/rbac/common/user/user_state.proto
+++ b/rbac/common/user/user_state.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Intel Corporation
+// Copyright 2018 Contributors to Hyperledger Sawtooth
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rbac/common/user/user_transaction.proto
+++ b/rbac/common/user/user_transaction.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Intel Corporation
+// Copyright 2018 Contributors to Hyperledger Sawtooth
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/rbac/common/sawtooth/batch_assertions.py
+++ b/tests/rbac/common/sawtooth/batch_assertions.py
@@ -40,6 +40,8 @@ class BatchAssertions(CommonAssertions):
     def assertEqualMessage(self, message1, message2):
         """A shallow comparison of the the json representation
         of two messages"""
+        self.assertIsNotNone(message1)
+        self.assertIsNotNone(message2)
         message1 = json.loads(json_format.MessageToJson(message1))
         message2 = json.loads(json_format.MessageToJson(message2))
         for prop in message1:

--- a/tests/rbac/common/user/confirm_manager_test.py
+++ b/tests/rbac/common/user/confirm_manager_test.py
@@ -1,0 +1,152 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import pytest
+import logging
+from uuid import uuid4
+
+from rbac.common import protobuf
+from rbac.common.protobuf.rbac_payload_pb2 import RBACPayload
+from rbac.common.user.user_manager import UserManager
+from rbac.common.user.manager import Manager
+from rbac.common.user.confirm_manager import ConfirmUpdateUserManager
+from tests.rbac.common.user.user_test_helper import UserTestHelper
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.user
+class ConfirmManagerTest(UserTestHelper):
+    def __init__(self, *args, **kwargs):
+        UserTestHelper.__init__(self, *args, **kwargs)
+
+    @pytest.mark.unit
+    def test_interface(self):
+        """Verify the expected interface"""
+        self.assertIsInstance(self.user, UserManager)
+        self.assertIsInstance(self.user.manager, Manager)
+        self.assertIsInstance(self.user.manager.confirm, ConfirmUpdateUserManager)
+        self.assertTrue(callable(self.user.manager.confirm.address))
+        self.assertTrue(callable(self.user.manager.confirm.make))
+        self.assertTrue(callable(self.user.manager.confirm.make_addresses))
+        self.assertTrue(callable(self.user.manager.confirm.make_payload))
+        self.assertTrue(callable(self.user.manager.confirm.create))
+        self.assertTrue(callable(self.user.manager.confirm.send))
+        self.assertTrue(callable(self.user.manager.confirm.get))
+
+    @pytest.mark.unit
+    def test_helper_interface(self):
+        """Verify the expected user test helper interface"""
+        self.assertTrue(callable(self.get_testdata_name))
+        self.assertTrue(callable(self.get_testdata_username))
+        self.assertTrue(callable(self.get_testdata_user))
+        self.assertTrue(callable(self.get_testdata_user_with_key))
+        self.assertTrue(callable(self.get_testdata_reason))
+        self.assertTrue(callable(self.get_testdata_user_created))
+        self.assertTrue(callable(self.get_testdata_user_created_with_manager))
+        self.assertTrue(callable(self.get_testdata_user_manager_proposal))
+
+    @pytest.mark.unit
+    def test_make(self):
+        """Test making the message"""
+        self.assertTrue(callable(self.user.manager.confirm.make))
+        user = self.get_testdata_user()
+        manager = self.get_testdata_user()
+        reason = self.get_testdata_reason()
+        proposal_id = uuid4().hex
+        message = self.user.manager.confirm.make(
+            proposal_id=proposal_id,
+            user_id=user.user_id,
+            manager_id=manager.user_id,
+            reason=reason,
+        )
+        self.assertIsInstance(
+            message, protobuf.user_transaction_pb2.ConfirmUpdateUserManager
+        )
+        self.assertEqual(message.proposal_id, proposal_id)
+        self.assertEqual(message.user_id, user.user_id)
+        self.assertEqual(message.manager_id, manager.user_id)
+        self.assertEqual(message.reason, reason)
+        return message
+
+    @pytest.mark.unit
+    def test_make_addresses(self):
+        """Test making the message addresses"""
+        self.assertTrue(callable(self.user.manager.confirm.make_addresses))
+        message = self.test_make()
+
+        inputs, outputs = self.user.manager.confirm.make_addresses(message=message)
+        user_address = self.user.address(object_id=message.user_id)
+        proposal_address = self.user.manager.confirm.address(
+            object_id=message.user_id, target_id=message.manager_id
+        )
+
+        self.assertIsInstance(inputs, list)
+        self.assertIsInstance(outputs, list)
+        self.assertIn(user_address, inputs)
+        self.assertIn(proposal_address, inputs)
+        self.assertEqual(len(inputs), 2)
+        self.assertEqual(outputs, inputs)
+
+    @pytest.mark.unit
+    def test_make_payload(self):
+        """Test making the message payload"""
+        self.assertTrue(callable(self.user.manager.confirm.make_payload))
+        message = self.test_make()
+        payload = self.user.manager.confirm.make_payload(message=message)
+        user_address = self.user.address(object_id=message.user_id)
+        proposal_address = self.user.manager.confirm.address(
+            object_id=message.user_id, target_id=message.manager_id
+        )
+        self.assertIsInstance(payload, RBACPayload)
+        inputs = list(payload.inputs)
+        outputs = list(payload.outputs)
+        self.assertIsInstance(inputs, list)
+        self.assertIsInstance(outputs, list)
+        self.assertIn(user_address, inputs)
+        self.assertIn(proposal_address, inputs)
+        self.assertEqual(len(inputs), 2)
+        self.assertEqual(inputs, outputs)
+        return payload
+
+    @pytest.mark.integration
+    def test_create(self):
+        """Test executing the message on the blockchain"""
+        self.assertTrue(callable(self.user.manager.confirm.create))
+        proposal, manager_key = self.get_testdata_user_manager_proposal()
+        reason = self.get_testdata_reason()
+        message = self.user.manager.confirm.make(
+            proposal_id=proposal.proposal_id,
+            user_id=proposal.object_id,
+            manager_id=proposal.target_id,
+            reason=reason,
+        )
+        got, status = self.user.manager.confirm.create(
+            signer_keypair=manager_key,
+            message=message,
+            object_id=proposal.object_id,
+            target_id=proposal.target_id,
+        )
+        self.assertStatusSuccess(status)
+        self.assertIsInstance(got, protobuf.proposal_state_pb2.Proposal)
+        self.assertEqual(
+            got.proposal_type, protobuf.proposal_state_pb2.Proposal.UPDATE_USER_MANAGER
+        )
+        self.assertEqual(got.proposal_id, proposal.proposal_id)
+        self.assertEqual(got.object_id, proposal.object_id)
+        self.assertEqual(got.target_id, proposal.target_id)
+        self.assertEqual(got.close_reason, reason)
+        self.assertEqual(got.status, protobuf.proposal_state_pb2.Proposal.CONFIRMED)
+        return got, manager_key

--- a/tests/rbac/common/user/create_user_test.py
+++ b/tests/rbac/common/user/create_user_test.py
@@ -1,0 +1,200 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import pytest
+import logging
+
+from rbac.addressing import addresser
+from rbac.common.crypto.keys import Key
+from rbac.common import protobuf
+from rbac.common.protobuf.rbac_payload_pb2 import RBACPayload
+from rbac.common.user.user_manager import UserManager
+from tests.rbac.common.user.user_test_helper import UserTestHelper
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.user
+class CreateUserTest(UserTestHelper):
+    def __init__(self, *args, **kwargs):
+        UserTestHelper.__init__(self, *args, **kwargs)
+
+    @pytest.mark.unit
+    def test_interface(self):
+        """Verify the expected interface"""
+        self.assertIsInstance(self.user, UserManager)
+        self.assertTrue(callable(self.user.address))
+        self.assertTrue(callable(self.user.make))
+        self.assertTrue(callable(self.user.make_with_key))
+        self.assertTrue(callable(self.user.make_addresses))
+        self.assertTrue(callable(self.user.make_payload))
+        self.assertTrue(callable(self.user.create))
+        self.assertTrue(callable(self.user.send))
+        self.assertTrue(callable(self.user.get))
+
+    @pytest.mark.unit
+    def test_helper_interface(self):
+        """Verify the expected user test helper interface"""
+        self.assertTrue(callable(self.get_testdata_name))
+        self.assertTrue(callable(self.get_testdata_username))
+        self.assertTrue(callable(self.get_testdata_user))
+        self.assertTrue(callable(self.get_testdata_user_with_key))
+        self.assertTrue(callable(self.get_testdata_reason))
+        self.assertTrue(callable(self.get_testdata_user_created))
+        self.assertTrue(callable(self.get_testdata_user_created_with_manager))
+
+    @pytest.mark.unit
+    @pytest.mark.address
+    def test_address(self):
+        """Test the address method and that it is in sync with the addresser"""
+        self.assertTrue(callable(self.user.address))
+
+        user = self.get_testdata_user()
+        self.assertIsInstance(user, protobuf.user_transaction_pb2.CreateUser)
+        self.assertIsInstance(user.user_id, str)
+        address1 = self.user.address(object_id=user.user_id)
+        address2 = addresser.make_user_address(user_id=user.user_id)
+        self.assertEqual(address1, address2)
+
+    @pytest.mark.unit
+    def test_make(self):
+        """Test getting a test data user with keys"""
+        self.assertTrue(callable(self.user.make))
+        name = self.get_testdata_name()
+        keypair = Key()
+        message = self.user.make(user_id=keypair.public_key, name=name)
+        self.assertIsInstance(message, protobuf.user_transaction_pb2.CreateUser)
+        self.assertIsInstance(message.user_id, str)
+        self.assertIsInstance(message.name, str)
+        self.assertEqual(message.user_id, keypair.public_key)
+        self.assertEqual(message.name, name)
+
+    @pytest.mark.unit
+    def test_make_with_key(self):
+        """Test getting a test data user with keys"""
+        self.assertTrue(callable(self.user.make_with_key))
+        name = self.get_testdata_name()
+        keypair = Key()
+        message, keypair = self.user.make_with_key(name=name)
+        self.assertIsInstance(message, protobuf.user_transaction_pb2.CreateUser)
+        self.assertIsInstance(message.user_id, str)
+        self.assertIsInstance(message.name, str)
+        self.assertIsInstance(keypair, Key)
+        self.assertEqual(message.user_id, keypair.public_key)
+        self.assertEqual(message.name, name)
+
+    @pytest.mark.unit
+    def test_make_addresses(self):
+        """Test making addresses without manager"""
+        self.assertTrue(callable(self.user.make_addresses))
+        self.assertTrue(callable(self.user.address))
+        self.assertTrue(callable(self.get_testdata_user))
+
+        message = self.get_testdata_user()
+        inputs, outputs = self.user.make_addresses(message=message)
+        user_address = self.user.address(object_id=message.user_id)
+        self.assertIsInstance(inputs, list)
+        self.assertIn(user_address, inputs)
+        self.assertEqual(len(inputs), 1)
+        self.assertEqual(inputs, outputs)
+
+    @pytest.mark.unit
+    def test_make_addresses_with_manager(self):
+        """Test making addresses with manager"""
+        self.assertTrue(callable(self.user.make_addresses))
+        self.assertTrue(callable(self.get_testdata_user_with_manager))
+
+        message, _, _, _ = self.get_testdata_user_with_manager()
+        inputs, outputs = self.user.make_addresses(message=message)
+        user_address = self.user.address(object_id=message.user_id)
+        manager_address = self.user.address(object_id=message.manager_id)
+        self.assertIsInstance(inputs, list)
+        self.assertIn(user_address, inputs)
+        self.assertIn(manager_address, inputs)
+        self.assertEqual(len(inputs), 2)
+        self.assertEqual(inputs, outputs)
+
+    @pytest.mark.unit
+    def test_make_payload(self):
+        """Test making a payload"""
+        self.assertTrue(callable(self.user.make_payload))
+        self.assertTrue(callable(self.user.address))
+        self.assertTrue(callable(self.get_testdata_user_with_key))
+
+        message, _ = self.get_testdata_user_with_key()
+        payload = self.user.make_payload(message=message)
+        self.assertEqual(payload.message_type, RBACPayload.CREATE_USER)
+        user_address = self.user.address(object_id=message.user_id)
+        inputs = list(payload.inputs)
+        outputs = list(payload.outputs)
+        self.assertIsInstance(inputs, list)
+        self.assertIn(user_address, inputs)
+        self.assertEqual(len(inputs), 1)
+        self.assertEqual(inputs, outputs)
+
+    @pytest.mark.unit
+    def test_make_payload_with_manager(self):
+        """Test making a payload with manager"""
+        self.assertTrue(callable(self.user.make_payload))
+        self.assertTrue(callable(self.user.address))
+        self.assertTrue(callable(self.get_testdata_user_with_key))
+
+        message, _, _, _ = self.get_testdata_user_with_manager()
+        payload = self.user.make_payload(message=message)
+        self.assertEqual(payload.message_type, RBACPayload.CREATE_USER)
+        user_address = self.user.address(object_id=message.user_id)
+        manager_address = self.user.address(object_id=message.manager_id)
+        inputs = list(payload.inputs)
+        outputs = list(payload.outputs)
+        self.assertIsInstance(inputs, list)
+        self.assertIn(user_address, inputs)
+        self.assertIn(manager_address, inputs)
+        self.assertEqual(len(inputs), 2)
+        self.assertEqual(inputs, outputs)
+
+    @pytest.mark.integration
+    def test_create(self, user=None, keypair=None):
+        """Test creating a user on the blockchain"""
+        self.assertTrue(callable(self.user.create))
+        self.assertTrue(callable(self.get_testdata_user_with_key))
+
+        if user is None:
+            user, keypair = self.get_testdata_user_with_key()
+
+        got, status = self.user.create(
+            signer_keypair=keypair, message=user, object_id=user.user_id
+        )
+        self.assertStatusSuccess(status)
+        self.assertEqualMessage(got, user)
+        return got, keypair
+
+    @pytest.mark.integration
+    def test_create_with_manager(self):
+        """Test creating a user with a manager on the blockchain"""
+        self.assertTrue(callable(self.user.create))
+        self.assertTrue(callable(self.get_testdata_user_created))
+        self.assertTrue(callable(self.get_testdata_user_with_key))
+
+        manager, manager_key = self.get_testdata_user_created()
+
+        user, user_keypair = self.get_testdata_user_with_key()
+        user.manager_id = manager.user_id
+
+        got, keypair = self.user.create(
+            signer_keypair=user_keypair, message=user, object_id=user.user_id
+        )
+        self.assertEqualMessage(got, user)
+        self.assertEqual(got.manager_id, manager.user_id)
+        return got, keypair, manager, manager_key

--- a/tests/rbac/common/user/propose_manager_test.py
+++ b/tests/rbac/common/user/propose_manager_test.py
@@ -1,0 +1,154 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import pytest
+import logging
+
+from rbac.common import protobuf
+from rbac.common.protobuf.rbac_payload_pb2 import RBACPayload
+from rbac.common.user.user_manager import UserManager
+from rbac.common.user.manager import Manager
+from rbac.common.user.propose_manager import ProposeUpdateUserManager
+from tests.rbac.common.user.user_test_helper import UserTestHelper
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.user
+class ProposeManagerTest(UserTestHelper):
+    def __init__(self, *args, **kwargs):
+        UserTestHelper.__init__(self, *args, **kwargs)
+
+    @pytest.mark.unit
+    def test_interface(self):
+        """Verify the expected interface"""
+        self.assertIsInstance(self.user, UserManager)
+        self.assertIsInstance(self.user.manager, Manager)
+        self.assertIsInstance(self.user.manager.propose, ProposeUpdateUserManager)
+        self.assertTrue(callable(self.user.manager.propose.address))
+        self.assertTrue(callable(self.user.manager.propose.make))
+        self.assertTrue(callable(self.user.manager.propose.make_addresses))
+        self.assertTrue(callable(self.user.manager.propose.make_payload))
+        self.assertTrue(callable(self.user.manager.propose.create))
+        self.assertTrue(callable(self.user.manager.propose.send))
+        self.assertTrue(callable(self.user.manager.propose.get))
+
+    @pytest.mark.unit
+    def test_helper_interface(self):
+        """Verify the expected user test helper interface"""
+        self.assertTrue(callable(self.get_testdata_name))
+        self.assertTrue(callable(self.get_testdata_username))
+        self.assertTrue(callable(self.get_testdata_user))
+        self.assertTrue(callable(self.get_testdata_user_with_key))
+        self.assertTrue(callable(self.get_testdata_reason))
+        self.assertTrue(callable(self.get_testdata_user_created))
+        self.assertTrue(callable(self.get_testdata_user_created_with_manager))
+
+    @pytest.mark.unit
+    def test_make(self):
+        """Test making the message"""
+        self.assertTrue(callable(self.user.manager.propose.make))
+        user = self.get_testdata_user()
+        manager = self.get_testdata_user()
+        reason = self.get_testdata_reason()
+        message = self.user.manager.propose.make(
+            user_id=user.user_id,
+            new_manager_id=manager.user_id,
+            reason=reason,
+            metadata=None,
+        )
+        self.assertIsInstance(
+            message, protobuf.user_transaction_pb2.ProposeUpdateUserManager
+        )
+        self.assertEqual(message.user_id, user.user_id)
+        self.assertEqual(message.new_manager_id, manager.user_id)
+        self.assertEqual(message.reason, reason)
+        return message
+
+    @pytest.mark.unit
+    def test_make_addresses(self):
+        """Test making the message addresses"""
+        self.assertTrue(callable(self.user.manager.propose.make_addresses))
+        message = self.test_make()
+
+        inputs, outputs = self.user.manager.propose.make_addresses(message=message)
+
+        user_address = self.user.address(object_id=message.user_id)
+        manager_address = self.user.address(object_id=message.new_manager_id)
+        proposal_address = self.user.manager.propose.address(
+            object_id=message.user_id, target_id=message.new_manager_id
+        )
+
+        self.assertIsInstance(inputs, list)
+        self.assertIsInstance(outputs, list)
+        self.assertIn(user_address, inputs)
+        self.assertIn(manager_address, inputs)
+        self.assertIn(proposal_address, inputs)
+        self.assertEqual(len(inputs), 3)
+        self.assertEqual(outputs, [proposal_address])
+
+    @pytest.mark.unit
+    def test_make_payload(self):
+        """Test making the message payload"""
+        self.assertTrue(callable(self.user.manager.propose.make_payload))
+        message = self.test_make()
+        payload = self.user.manager.propose.make_payload(message=message)
+        user_address = self.user.address(object_id=message.user_id)
+        manager_address = self.user.address(object_id=message.new_manager_id)
+        proposal_address = self.user.manager.propose.address(
+            object_id=message.user_id, target_id=message.new_manager_id
+        )
+        self.assertIsInstance(payload, RBACPayload)
+        inputs = list(payload.inputs)
+        outputs = list(payload.outputs)
+        self.assertIsInstance(inputs, list)
+        self.assertIsInstance(outputs, list)
+        self.assertIn(user_address, inputs)
+        self.assertIn(manager_address, inputs)
+        self.assertIn(proposal_address, inputs)
+        self.assertEqual(len(inputs), 3)
+        self.assertEqual(outputs, [proposal_address])
+        return payload
+
+    @pytest.mark.integration
+    def test_create(self):
+        """Test executing the message on the blockchain"""
+        self.assertTrue(callable(self.user.manager.propose.create))
+        user, user_key = self.get_testdata_user_created()
+        manager, manager_key = self.get_testdata_user_created()
+        reason = self.get_testdata_reason()
+        message = self.user.manager.propose.make(
+            user_id=user.user_id,
+            new_manager_id=manager.user_id,
+            reason=reason,
+            metadata=None,
+        )
+        got, status = self.user.manager.propose.create(
+            signer_keypair=user_key,
+            message=message,
+            object_id=user.user_id,
+            target_id=manager.user_id,
+        )
+        self.assertStatusSuccess(status)
+        self.assertIsInstance(got, protobuf.proposal_state_pb2.Proposal)
+        self.assertEqual(
+            got.proposal_type, protobuf.proposal_state_pb2.Proposal.UPDATE_USER_MANAGER
+        )
+        self.assertEqual(got.proposal_id, message.proposal_id)
+        self.assertEqual(got.object_id, user.user_id)
+        self.assertEqual(got.target_id, manager.user_id)
+        self.assertEqual(got.opener, user_key.public_key)
+        self.assertEqual(got.open_reason, reason)
+        return got, manager_key

--- a/tests/rbac/common/user/reject_manager_test.py
+++ b/tests/rbac/common/user/reject_manager_test.py
@@ -1,0 +1,144 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import pytest
+import logging
+from uuid import uuid4
+
+from rbac.common import protobuf
+from rbac.common.protobuf.rbac_payload_pb2 import RBACPayload
+from rbac.common.user.user_manager import UserManager
+from rbac.common.user.manager import Manager
+from rbac.common.user.reject_manager import RejectUpdateUserManager
+from tests.rbac.common.user.user_test_helper import UserTestHelper
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.user
+class RejectManagerTest(UserTestHelper):
+    def __init__(self, *args, **kwargs):
+        UserTestHelper.__init__(self, *args, **kwargs)
+
+    @pytest.mark.unit
+    def test_interface(self):
+        """Verify the expected interface"""
+        self.assertIsInstance(self.user, UserManager)
+        self.assertIsInstance(self.user.manager, Manager)
+        self.assertIsInstance(self.user.manager.reject, RejectUpdateUserManager)
+        self.assertTrue(callable(self.user.manager.reject.address))
+        self.assertTrue(callable(self.user.manager.reject.make))
+        self.assertTrue(callable(self.user.manager.reject.make_addresses))
+        self.assertTrue(callable(self.user.manager.reject.make_payload))
+        self.assertTrue(callable(self.user.manager.reject.create))
+        self.assertTrue(callable(self.user.manager.reject.send))
+        self.assertTrue(callable(self.user.manager.reject.get))
+
+    @pytest.mark.unit
+    def test_helper_interface(self):
+        """Verify the expected user test helper interface"""
+        self.assertTrue(callable(self.get_testdata_name))
+        self.assertTrue(callable(self.get_testdata_username))
+        self.assertTrue(callable(self.get_testdata_user))
+        self.assertTrue(callable(self.get_testdata_user_with_key))
+        self.assertTrue(callable(self.get_testdata_reason))
+        self.assertTrue(callable(self.get_testdata_user_created))
+        self.assertTrue(callable(self.get_testdata_user_created_with_manager))
+        self.assertTrue(callable(self.get_testdata_user_manager_proposal))
+
+    @pytest.mark.unit
+    def test_make(self):
+        """Test making the message"""
+        self.assertTrue(callable(self.user.manager.reject.make))
+        user = self.get_testdata_user()
+        manager = self.get_testdata_user()
+        reason = self.get_testdata_reason()
+        proposal_id = uuid4().hex
+        message = self.user.manager.reject.make(
+            proposal_id=proposal_id,
+            user_id=user.user_id,
+            manager_id=manager.user_id,
+            reason=reason,
+        )
+        self.assertIsInstance(
+            message, protobuf.user_transaction_pb2.RejectUpdateUserManager
+        )
+        self.assertEqual(message.proposal_id, proposal_id)
+        self.assertEqual(message.user_id, user.user_id)
+        self.assertEqual(message.manager_id, manager.user_id)
+        self.assertEqual(message.reason, reason)
+        return message
+
+    @pytest.mark.unit
+    def test_make_addresses(self):
+        """Test making a propose manager message"""
+        self.assertTrue(callable(self.user.manager.reject.make_addresses))
+        message = self.test_make()
+
+        inputs, outputs = self.user.manager.reject.make_addresses(message=message)
+        proposal_address = self.user.manager.reject.address(
+            object_id=message.user_id, target_id=message.manager_id
+        )
+
+        self.assertEqual(inputs, [proposal_address])
+        self.assertEqual(outputs, [proposal_address])
+
+    @pytest.mark.unit
+    def test_make_payload(self):
+        """Test making a propose manager message"""
+        self.assertTrue(callable(self.user.manager.reject.make_payload))
+        message = self.test_make()
+        payload = self.user.manager.reject.make_payload(message=message)
+        proposal_address = self.user.manager.reject.address(
+            object_id=message.user_id, target_id=message.manager_id
+        )
+        self.assertIsInstance(payload, RBACPayload)
+        inputs = list(payload.inputs)
+        outputs = list(payload.outputs)
+        self.assertIsInstance(inputs, list)
+        self.assertIsInstance(outputs, list)
+        self.assertEqual(inputs, [proposal_address])
+        self.assertEqual(outputs, [proposal_address])
+        return payload
+
+    @pytest.mark.integration
+    def test_create(self):
+        """Test creating an user reject manager proposal"""
+        self.assertTrue(callable(self.user.manager.reject.create))
+        proposal, manager_key = self.get_testdata_user_manager_proposal()
+        reason = self.get_testdata_reason()
+        message = self.user.manager.reject.make(
+            proposal_id=proposal.proposal_id,
+            user_id=proposal.object_id,
+            manager_id=proposal.target_id,
+            reason=reason,
+        )
+        got, status = self.user.manager.reject.create(
+            signer_keypair=manager_key,
+            message=message,
+            object_id=proposal.object_id,
+            target_id=proposal.target_id,
+        )
+        self.assertStatusSuccess(status)
+        self.assertIsInstance(got, protobuf.proposal_state_pb2.Proposal)
+        self.assertEqual(
+            got.proposal_type, protobuf.proposal_state_pb2.Proposal.UPDATE_USER_MANAGER
+        )
+        self.assertEqual(got.proposal_id, proposal.proposal_id)
+        self.assertEqual(got.object_id, proposal.object_id)
+        self.assertEqual(got.target_id, proposal.target_id)
+        self.assertEqual(got.close_reason, reason)
+        self.assertEqual(got.status, protobuf.proposal_state_pb2.Proposal.REJECTED)
+        return got, manager_key

--- a/tests/rbac/common/user/user_manager_test.py
+++ b/tests/rbac/common/user/user_manager_test.py
@@ -16,19 +16,18 @@
 import pytest
 import logging
 import random
+from uuid import uuid4
 
 from rbac.addressing import addresser
 from rbac.common.crypto.keys import Key
+from rbac.common import protobuf
 from rbac.common.protobuf.rbac_payload_pb2 import RBACPayload
-from rbac.common.protobuf import user_transaction_pb2
 from rbac.common.user.user_manager import UserManager
 from tests.rbac.common.user.user_assertions import UserAssertions
 
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.user
-@pytest.mark.user_it
 class UserManagerTest(UserManager, UserAssertions):
     def __init__(self, *args, **kwargs):
         UserAssertions.__init__(self, *args, **kwargs)
@@ -36,11 +35,12 @@ class UserManagerTest(UserManager, UserAssertions):
 
     def get_testdata_user(self, user_id=None):
         """Get a test data CreateUser message"""
-        name = self.get_testdata_name()
         if user_id is None:
-            user_id = name
+            user, _ = self.get_testdata_user_with_key()
+            return user
+        name = self.get_testdata_name()
         user = self.make(user_id=user_id, name=name)
-        self.assertIsInstance(user, user_transaction_pb2.CreateUser)
+        self.assertIsInstance(user, protobuf.user_transaction_pb2.CreateUser)
         self.assertEqual(user.user_id, user_id)
         self.assertEqual(user.name, name)
         return user
@@ -49,7 +49,7 @@ class UserManagerTest(UserManager, UserAssertions):
         """Get a test data CreateUser message with a new keypair"""
         name = self.get_testdata_name()
         user, keypair = self.make_with_key(name=name)
-        self.assertIsInstance(user, user_transaction_pb2.CreateUser)
+        self.assertIsInstance(user, protobuf.user_transaction_pb2.CreateUser)
         self.assertIsInstance(keypair, Key)
         self.assertEqual(user.user_id, keypair.public_key)
         self.assertEqual(user.name, name)
@@ -72,11 +72,17 @@ class UserManagerTest(UserManager, UserAssertions):
         """Get a random username"""
         return "user" + str(random.randint(10000, 100000))
 
+    def get_testdata_reason(self):
+        """Get a random reason"""
+        return "Because" + str(random.randint(10000, 100000))
+
     def get_testdata_inputs(self, message_type=RBACPayload.CREATE_USER):
         """Get test data inputs for a create user message"""
         if message_type == RBACPayload.CREATE_USER:
             signer = Key()
-            message = user_transaction_pb2.CreateUser(name=self.get_testdata_name())
+            message = protobuf.user_transaction_pb2.CreateUser(
+                name=self.get_testdata_name()
+            )
             message.user_id = signer.public_key
             inputs = [self.address(signer.public_key)]
             outputs = inputs
@@ -85,20 +91,6 @@ class UserManagerTest(UserManager, UserAssertions):
             raise Exception(
                 "get_testdata_payload doesn't yet support {}".format(message_type)
             )
-
-    def make_message_create_test(self, user):
-        """Test making a Create User message"""
-        message, message_type, inputs, outputs = self.make_message_create(user=user)
-        self.assertEqual(message_type, RBACPayload.CREATE_USER)
-        user_address = self.address(user_id=user.user_id)
-        self.assertIn(user_address, inputs)
-        self.assertIn(user_address, outputs)
-        if user.manager_id:
-            manager_address = self.address(user_id=user.manager_id)
-            self.assertIn(manager_address, inputs)
-            self.assertIn(manager_address, outputs)
-
-        return message, message_type, inputs, outputs
 
     @pytest.mark.unit
     def test_user_manager_interface(self):
@@ -125,9 +117,9 @@ class UserManagerTest(UserManager, UserAssertions):
     def test_addresser(self):
         """Test the addresser and user addresser are in sync"""
         user = self.get_testdata_user()
-        self.assertIsInstance(user, user_transaction_pb2.CreateUser)
+        self.assertIsInstance(user, protobuf.user_transaction_pb2.CreateUser)
         self.assertIsInstance(user.user_id, str)
-        address1 = self.address(user_id=user.user_id)
+        address1 = self.address(object_id=user.user_id)
         address2 = addresser.make_user_address(user_id=user.user_id)
         self.assertEqual(address1, address2)
 
@@ -135,7 +127,7 @@ class UserManagerTest(UserManager, UserAssertions):
     def test_get_testdata_user_with_keys(self):
         """Test getting a test data user with keys"""
         user, keypair = self.get_testdata_user_with_key()
-        self.assertIsInstance(user, user_transaction_pb2.CreateUser)
+        self.assertIsInstance(user, protobuf.user_transaction_pb2.CreateUser)
         self.assertIsInstance(user.user_id, str)
         self.assertIsInstance(user.name, str)
         self.assertIsInstance(keypair, Key)
@@ -149,7 +141,7 @@ class UserManagerTest(UserManager, UserAssertions):
         inputs, outputs = self.make_addresses(message=message)
         self.assertIsInstance(inputs, list)
         self.assertEqual(len(inputs), 1)
-        self.assertEqual(inputs[0], self.address(user_id=message.user_id))
+        self.assertEqual(inputs[0], self.address(object_id=message.user_id))
         self.assertEqual(inputs, outputs)
 
     @pytest.mark.unit
@@ -161,8 +153,8 @@ class UserManagerTest(UserManager, UserAssertions):
         inputs, outputs = self.make_addresses(message=message)
         self.assertIsInstance(inputs, list)
         self.assertEqual(len(inputs), 2)
-        self.assertEqual(inputs[0], self.address(user_id=message.user_id))
-        self.assertEqual(inputs[1], self.address(user_id=message.manager_id))
+        self.assertEqual(inputs[0], self.address(object_id=message.user_id))
+        self.assertEqual(inputs[1], self.address(object_id=message.manager_id))
         self.assertEqual(inputs, outputs)
 
     @pytest.mark.unit
@@ -177,26 +169,19 @@ class UserManagerTest(UserManager, UserAssertions):
         )
 
     @pytest.mark.integration
-    @pytest.mark.user_it
     def test_create(self, user=None, keypair=None):
         """Test creating a user on the blockchain"""
         if user is None:
             user, keypair = self.get_testdata_user_with_key()
 
-        got, status, transaction, _, _, _ = self.create(
-            signer_keypair=keypair, message=user, do_get=True
-        )
-        self.assertValidTransaction(
-            transaction=transaction,
-            payload=self.make_payload(message=user),
-            signer_public_key=keypair.public_key,
+        got, status = self.create(
+            signer_keypair=keypair, message=user, object_id=user.user_id
         )
         self.assertStatusSuccess(status)
         self.assertEqualMessage(got, user)
         return got, keypair
 
     @pytest.mark.integration
-    @pytest.mark.user_it
     def test_create_with_manager(self):
         """Test creating a user with a manager on the blockchain"""
         manager, manager_key = self.test_create()
@@ -207,3 +192,301 @@ class UserManagerTest(UserManager, UserAssertions):
         got, keypair = self.test_create(user=user, keypair=user_keypair)
         self.assertEqual(got.manager_id, manager.user_id)
         return got, keypair, manager, manager_key
+
+    @pytest.mark.unit
+    def test_user_managers_interface(self):
+        """Test the expected propose manager interface"""
+        self.assertTrue(callable(self.manager.propose.make))
+        self.assertTrue(callable(self.manager.propose.make_addresses))
+        self.assertTrue(callable(self.manager.propose.make_payload))
+        self.assertTrue(callable(self.manager.propose.create))
+        self.assertTrue(callable(self.manager.propose.send))
+        self.assertTrue(callable(self.manager.propose.get))
+
+        self.assertTrue(callable(self.manager.reject.make))
+        self.assertTrue(callable(self.manager.reject.make_addresses))
+        self.assertTrue(callable(self.manager.reject.make_payload))
+        self.assertTrue(callable(self.manager.reject.create))
+        self.assertTrue(callable(self.manager.reject.send))
+        self.assertTrue(callable(self.manager.reject.get))
+
+        self.assertTrue(callable(self.manager.confirm.make))
+        self.assertTrue(callable(self.manager.confirm.make_addresses))
+        self.assertTrue(callable(self.manager.confirm.make_payload))
+        self.assertTrue(callable(self.manager.confirm.create))
+        self.assertTrue(callable(self.manager.confirm.send))
+        self.assertTrue(callable(self.manager.confirm.get))
+
+    @pytest.mark.unit
+    def test_user_manager_propose_make(self):
+        """Test making a propose manager message"""
+        self.assertTrue(callable(self.manager.propose.make))
+        user = self.get_testdata_user()
+        manager = self.get_testdata_user()
+        reason = self.get_testdata_reason()
+        message = self.manager.propose.make(
+            user_id=user.user_id,
+            new_manager_id=manager.user_id,
+            reason=reason,
+            metadata=None,
+        )
+        self.assertIsInstance(
+            message, protobuf.user_transaction_pb2.ProposeUpdateUserManager
+        )
+        self.assertEqual(message.user_id, user.user_id)
+        self.assertEqual(message.new_manager_id, manager.user_id)
+        self.assertEqual(message.reason, reason)
+        return message
+
+    @pytest.mark.unit
+    def test_user_manager_reject_make(self):
+        """Test making a reject manager message"""
+        self.assertTrue(callable(self.manager.reject.make))
+        user = self.get_testdata_user()
+        manager = self.get_testdata_user()
+        reason = self.get_testdata_reason()
+        proposal_id = uuid4().hex
+        message = self.manager.reject.make(
+            proposal_id=proposal_id,
+            user_id=user.user_id,
+            manager_id=manager.user_id,
+            reason=reason,
+        )
+        self.assertIsInstance(
+            message, protobuf.user_transaction_pb2.RejectUpdateUserManager
+        )
+        self.assertEqual(message.proposal_id, proposal_id)
+        self.assertEqual(message.user_id, user.user_id)
+        self.assertEqual(message.manager_id, manager.user_id)
+        self.assertEqual(message.reason, reason)
+        return message
+
+    @pytest.mark.unit
+    def test_user_manager_confirm_make(self):
+        """Test making a confirm manager message"""
+        self.assertTrue(callable(self.manager.confirm.make))
+        user = self.get_testdata_user()
+        manager = self.get_testdata_user()
+        reason = self.get_testdata_reason()
+        proposal_id = uuid4().hex
+        message = self.manager.confirm.make(
+            proposal_id=proposal_id,
+            user_id=user.user_id,
+            manager_id=manager.user_id,
+            reason=reason,
+        )
+        self.assertIsInstance(
+            message, protobuf.user_transaction_pb2.ConfirmUpdateUserManager
+        )
+        self.assertEqual(message.proposal_id, proposal_id)
+        self.assertEqual(message.user_id, user.user_id)
+        self.assertEqual(message.manager_id, manager.user_id)
+        self.assertEqual(message.reason, reason)
+        return message
+
+    @pytest.mark.unit
+    def test_user_manager_propose_addresses(self):
+        """Test making a propose manager message"""
+        self.assertTrue(callable(self.manager.propose.make_addresses))
+        message = self.test_user_manager_propose_make()
+
+        inputs, outputs = self.manager.propose.make_addresses(message=message)
+        user_address = self.address(object_id=message.user_id)
+        manager_address = self.address(object_id=message.new_manager_id)
+        proposal_address = self.manager.propose.address(
+            object_id=message.user_id, target_id=message.new_manager_id
+        )
+
+        self.assertIsInstance(inputs, list)
+        self.assertIsInstance(outputs, list)
+        self.assertIn(user_address, inputs)
+        self.assertIn(manager_address, inputs)
+        self.assertIn(proposal_address, inputs)
+        self.assertEqual(len(inputs), 3)
+        self.assertEqual(outputs, [proposal_address])
+
+    @pytest.mark.unit
+    def test_user_manager_reject_addresses(self):
+        """Test making a propose manager message"""
+        self.assertTrue(callable(self.manager.reject.make_addresses))
+        message = self.test_user_manager_reject_make()
+
+        inputs, outputs = self.manager.reject.make_addresses(message=message)
+        proposal_address = self.manager.reject.address(
+            object_id=message.user_id, target_id=message.manager_id
+        )
+
+        self.assertEqual(inputs, [proposal_address])
+        self.assertEqual(outputs, [proposal_address])
+
+    @pytest.mark.unit
+    def test_user_manager_confirm_addresses(self):
+        """Test making a propose manager message"""
+        self.assertTrue(callable(self.manager.confirm.make_addresses))
+        message = self.test_user_manager_confirm_make()
+
+        inputs, outputs = self.manager.confirm.make_addresses(message=message)
+        user_address = self.address(object_id=message.user_id)
+        proposal_address = self.manager.propose.address(
+            object_id=message.user_id, target_id=message.manager_id
+        )
+
+        self.assertIsInstance(inputs, list)
+        self.assertIsInstance(outputs, list)
+        self.assertIn(user_address, inputs)
+        self.assertIn(proposal_address, inputs)
+        self.assertEqual(len(inputs), 2)
+        self.assertEqual(outputs, inputs)
+
+    @pytest.mark.unit
+    def test_user_manager_propose_payload(self):
+        """Test making a propose manager message"""
+        self.assertTrue(callable(self.manager.propose.make_payload))
+        message = self.test_user_manager_propose_make()
+        payload = self.manager.propose.make_payload(message=message)
+        user_address = self.address(object_id=message.user_id)
+        manager_address = self.address(object_id=message.new_manager_id)
+        proposal_address = self.manager.propose.address(
+            object_id=message.user_id, target_id=message.new_manager_id
+        )
+        self.assertIsInstance(payload, RBACPayload)
+        inputs = list(payload.inputs)
+        outputs = list(payload.outputs)
+        self.assertIsInstance(inputs, list)
+        self.assertIsInstance(outputs, list)
+        self.assertIn(user_address, inputs)
+        self.assertIn(manager_address, inputs)
+        self.assertIn(proposal_address, inputs)
+        self.assertEqual(len(inputs), 3)
+        self.assertEqual(outputs, [proposal_address])
+        return payload
+
+    @pytest.mark.unit
+    def test_user_manager_reject_payload(self):
+        """Test making a propose manager message"""
+        self.assertTrue(callable(self.manager.reject.make_payload))
+        message = self.test_user_manager_reject_make()
+        payload = self.manager.reject.make_payload(message=message)
+        proposal_address = self.manager.reject.address(
+            object_id=message.user_id, target_id=message.manager_id
+        )
+        self.assertIsInstance(payload, RBACPayload)
+        inputs = list(payload.inputs)
+        outputs = list(payload.outputs)
+        self.assertIsInstance(inputs, list)
+        self.assertIsInstance(outputs, list)
+        self.assertEqual(inputs, [proposal_address])
+        self.assertEqual(outputs, [proposal_address])
+        return payload
+
+    @pytest.mark.unit
+    def test_user_manager_confirm_payload(self):
+        """Test making a confirm manager message"""
+        self.assertTrue(callable(self.manager.confirm.make_payload))
+        message = self.test_user_manager_confirm_make()
+        payload = self.manager.confirm.make_payload(message=message)
+        user_address = self.address(object_id=message.user_id)
+        proposal_address = self.manager.confirm.address(
+            object_id=message.user_id, target_id=message.manager_id
+        )
+        self.assertIsInstance(payload, RBACPayload)
+        inputs = list(payload.inputs)
+        outputs = list(payload.outputs)
+        self.assertIsInstance(inputs, list)
+        self.assertIsInstance(outputs, list)
+        self.assertIn(user_address, inputs)
+        self.assertIn(proposal_address, inputs)
+        self.assertEqual(len(inputs), 2)
+        self.assertEqual(inputs, outputs)
+        return payload
+
+    @pytest.mark.integration
+    def test_user_manager_propose_create(self):
+        """Test creating an user update manager proposal"""
+        self.assertTrue(callable(self.manager.propose.create))
+        user, user_key = self.test_create()
+        manager, manager_key = self.test_create()
+        reason = self.get_testdata_reason()
+        message = self.manager.propose.make(
+            user_id=user.user_id,
+            new_manager_id=manager.user_id,
+            reason=reason,
+            metadata=None,
+        )
+        got, status = self.manager.propose.create(
+            signer_keypair=user_key,
+            message=message,
+            object_id=user.user_id,
+            target_id=manager.user_id,
+        )
+        self.assertStatusSuccess(status)
+        self.assertIsInstance(got, protobuf.proposal_state_pb2.Proposal)
+        self.assertEqual(
+            got.proposal_type, protobuf.proposal_state_pb2.Proposal.UPDATE_USER_MANAGER
+        )
+        self.assertEqual(got.proposal_id, message.proposal_id)
+        self.assertEqual(got.object_id, user.user_id)
+        self.assertEqual(got.target_id, manager.user_id)
+        self.assertEqual(got.opener, user_key.public_key)
+        self.assertEqual(got.open_reason, reason)
+        return got, manager_key
+
+    @pytest.mark.integration
+    def test_user_manager_reject_create(self):
+        """Test creating an user reject manager proposal"""
+        self.assertTrue(callable(self.manager.reject.create))
+        proposal, manager_key = self.test_user_manager_propose_create()
+        reason = self.get_testdata_reason()
+        message = self.manager.reject.make(
+            proposal_id=proposal.proposal_id,
+            user_id=proposal.object_id,
+            manager_id=proposal.target_id,
+            reason=reason,
+        )
+        got, status = self.manager.reject.create(
+            signer_keypair=manager_key,
+            message=message,
+            object_id=proposal.object_id,
+            target_id=proposal.target_id,
+        )
+        self.assertStatusSuccess(status)
+        self.assertIsInstance(got, protobuf.proposal_state_pb2.Proposal)
+        self.assertEqual(
+            got.proposal_type, protobuf.proposal_state_pb2.Proposal.UPDATE_USER_MANAGER
+        )
+        self.assertEqual(got.proposal_id, proposal.proposal_id)
+        self.assertEqual(got.object_id, proposal.object_id)
+        self.assertEqual(got.target_id, proposal.target_id)
+        self.assertEqual(got.close_reason, reason)
+        self.assertEqual(got.status, protobuf.proposal_state_pb2.Proposal.REJECTED)
+        return got, manager_key
+
+    @pytest.mark.integration
+    def test_user_manager_confirm_create(self):
+        """Test creating an user confirm manager proposal"""
+        self.assertTrue(callable(self.manager.confirm.create))
+        proposal, manager_key = self.test_user_manager_propose_create()
+        reason = self.get_testdata_reason()
+        message = self.manager.confirm.make(
+            proposal_id=proposal.proposal_id,
+            user_id=proposal.object_id,
+            manager_id=proposal.target_id,
+            reason=reason,
+        )
+        got, status = self.manager.confirm.create(
+            signer_keypair=manager_key,
+            message=message,
+            object_id=proposal.object_id,
+            target_id=proposal.target_id,
+        )
+        self.assertStatusSuccess(status)
+        self.assertIsInstance(got, protobuf.proposal_state_pb2.Proposal)
+        self.assertEqual(
+            got.proposal_type, protobuf.proposal_state_pb2.Proposal.UPDATE_USER_MANAGER
+        )
+        self.assertEqual(got.proposal_id, proposal.proposal_id)
+        self.assertEqual(got.object_id, proposal.object_id)
+        self.assertEqual(got.target_id, proposal.target_id)
+        self.assertEqual(got.close_reason, reason)
+        self.assertEqual(got.status, protobuf.proposal_state_pb2.Proposal.CONFIRMED)
+        return got, manager_key

--- a/tests/rbac/common/user/user_test_helper.py
+++ b/tests/rbac/common/user/user_test_helper.py
@@ -1,0 +1,143 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import pytest
+import logging
+import random
+
+from rbac.common.crypto.keys import Key
+from rbac.common import protobuf
+from rbac.common.user.user_manager import UserManager
+from tests.rbac.common.sawtooth.batch_assertions import BatchAssertions
+
+LOGGER = logging.getLogger(__name__)
+
+
+class UserTestHelper(BatchAssertions):
+    def __init__(self, *args, **kwargs):
+        BatchAssertions.__init__(self, *args, **kwargs)
+        self.user = UserManager()
+
+    def get_testdata_user(self, user_id=None):
+        """Get a test data CreateUser message"""
+        self.assertTrue(callable(self.user.make))
+        if user_id is None:
+            user, _ = self.get_testdata_user_with_key()
+            return user
+        name = self.get_testdata_name()
+        user = self.user.make(user_id=user_id, name=name)
+        self.assertIsInstance(user, protobuf.user_transaction_pb2.CreateUser)
+        self.assertEqual(user.user_id, user_id)
+        self.assertEqual(user.name, name)
+        return user
+
+    def get_testdata_user_with_key(self):
+        """Get a test data CreateUser message with a new keypair"""
+        self.assertTrue(callable(self.user.make_with_key))
+        name = self.get_testdata_name()
+        user, keypair = self.user.make_with_key(name=name)
+        self.assertIsInstance(user, protobuf.user_transaction_pb2.CreateUser)
+        self.assertIsInstance(keypair, Key)
+        self.assertEqual(user.user_id, keypair.public_key)
+        self.assertEqual(user.name, name)
+        return user, keypair
+
+    def get_testdata_user_with_manager(self):
+        """Get a test data user and manager"""
+        manager, manager_key = self.get_testdata_user_with_key()
+        user, user_key = self.user.make_with_key(
+            name=self.get_testdata_name(), manager_id=manager.user_id
+        )
+        self.assertEqual(manager.user_id, user.manager_id)
+        return user, user_key, manager, manager_key
+
+    def get_testdata_name(self):
+        """Get a random name"""
+        return "User" + str(random.randint(1000, 10000))
+
+    def get_testdata_username(self):
+        """Get a random username"""
+        return "user" + str(random.randint(10000, 100000))
+
+    def get_testdata_reason(self):
+        """Get a random reason"""
+        return "Because" + str(random.randint(10000, 100000))
+
+    @pytest.mark.unit
+    def test_get_testdata_user_with_keys(self):
+        """Test getting a test data user with keys"""
+        user, keypair = self.get_testdata_user_with_key()
+        self.assertIsInstance(user, protobuf.user_transaction_pb2.CreateUser)
+        self.assertIsInstance(user.user_id, str)
+        self.assertIsInstance(user.name, str)
+        self.assertIsInstance(keypair, Key)
+
+    @pytest.mark.integration
+    def get_testdata_user_created(self, user=None, keypair=None):
+        """Test creating a user on the blockchain"""
+        self.assertTrue(callable(self.user.create))
+        if user is None:
+            user, keypair = self.get_testdata_user_with_key()
+
+        got, status = self.user.create(
+            signer_keypair=keypair, message=user, object_id=user.user_id
+        )
+        self.assertStatusSuccess(status)
+        self.assertEqualMessage(got, user)
+        return got, keypair
+
+    @pytest.mark.integration
+    def get_testdata_user_created_with_manager(self):
+        """Test creating a user with a manager on the blockchain"""
+        self.assertTrue(callable(self.user.create))
+        manager, manager_key = self.get_testdata_user_created()
+
+        user, user_keypair = self.get_testdata_user_with_key()
+        user.manager_id = manager.user_id
+
+        got, keypair = self.get_testdata_user_created(user=user, keypair=user_keypair)
+        self.assertEqual(got.manager_id, manager.user_id)
+        return got, keypair, manager, manager_key
+
+    @pytest.mark.integration
+    def get_testdata_user_manager_proposal(self):
+        """Return a test update manager proposal"""
+        self.assertTrue(callable(self.user.manager.propose.create))
+        user, user_key = self.get_testdata_user_created()
+        manager, manager_key = self.get_testdata_user_created()
+        reason = self.get_testdata_reason()
+        message = self.user.manager.propose.make(
+            user_id=user.user_id,
+            new_manager_id=manager.user_id,
+            reason=reason,
+            metadata=None,
+        )
+        got, status = self.user.manager.propose.create(
+            signer_keypair=user_key,
+            message=message,
+            object_id=user.user_id,
+            target_id=manager.user_id,
+        )
+        self.assertStatusSuccess(status)
+        self.assertIsInstance(got, protobuf.proposal_state_pb2.Proposal)
+        self.assertEqual(
+            got.proposal_type, protobuf.proposal_state_pb2.Proposal.UPDATE_USER_MANAGER
+        )
+        self.assertEqual(got.proposal_id, message.proposal_id)
+        self.assertEqual(got.object_id, user.user_id)
+        self.assertEqual(got.target_id, manager.user_id)
+        self.assertEqual(got.opener, user_key.public_key)
+        self.assertEqual(got.open_reason, reason)
+        return got, manager_key


### PR DESCRIPTION
Adds user manager update proposal, confirm and reject
messages to the standard RBAC User Library and implements
via a new message_base base class.