### PR TITLE
Add support for windows developers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,6 @@ limitations under the License.
 # LDAP_USER=ldap_user
 # LDAP_PASS=ldap_user
 # DELTA_SYNC_INTERVAL_SECONDS=3600
+
+# <-- Required Environment Variables -->
+COMPOSE_CONVERT_WINDOWS_PATHS=1

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# always use LF line endings (windwos line endings break docker)
+* text eol=lf

--- a/bin/start
+++ b/bin/start
@@ -35,6 +35,12 @@ EOM
 
 }
 
+if ! [ -e .env.example] 
+then
+    echo ".env file not found. Creating one from .env.example ..."
+    cp ./.env.example ./.env
+fi
+
 if [[ "$1" =~ ^((-{1,2})([Hh]$|[Hh][Ee][Ll][Pp])|)$ ]]; then
     usage; exit 1
 else


### PR DESCRIPTION
*  Locally setting git to NOT convert from unix to windows style line endings.
*  Including COMPOSE_CONVERT_WINDOWS_PATHS=1 in .env.example 
to fix docker-compose issues.

Signed-off-by: jbobo <j.ned@bobonana.me>