### PR TITLE
Manually change package-lock.json 'merge' dependency

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4267,7 +4267,7 @@
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
       "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
       "requires": {
-        "merge": "^1.2.0"
+        "merge": "^1.2.1"
       }
     },
     "execa": {


### PR DESCRIPTION
Exploratory change to resolve GitHub security alert requiring
the package 'merge' to be >= 1.2.1.

---

_PR  #432 closed in favor of this one._

_- exec-sh left unchanged._


Signed-off-by: Phillip Gobin <pgobin@Phillips-MacBook.local>