### PR TITLE
Remove sanic-oauth dependency

### DIFF
--- a/requirement.local.txt
+++ b/requirement.local.txt
@@ -1,1 +1,2 @@
+PyYAML==3.13
 black==18.9b0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ rethinkdb==2.3.0.post6
 sawtooth_sdk==1.0.5
 sawtooth_signing==1.0.5
 sanic==0.8.3
-sanic-oauth==0.2.5
 protobuf==3.6.1
 requests==2.20.0
 pyzmq==17.1.2


### PR DESCRIPTION
Sanic-oauth is not being used, and is not compatible with Python 3.5
Will need to address python version issue if/when this
is required.