### PR TITLE
Fixed AD/AAD initial syncs checking uninitialized table

### DIFF
--- a/rbac/providers/azure/initial_inbound_sync.py
+++ b/rbac/providers/azure/initial_inbound_sync.py
@@ -26,7 +26,8 @@ from rbac.providers.common.inbound_filters import (
     inbound_user_filter,
     inbound_group_filter,
 )
-from rbac.providers.common.common import save_sync_time, check_for_sync
+from rbac.providers.common.common import save_sync_time, check_last_sync
+
 
 logging.basicConfig(level=logging.INFO)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
@@ -211,9 +212,11 @@ def initialize_aad_sync():
     connect_to_db()
     LOGGER.info("Successfully connected to RethinkDB!")
 
-    db_user_payload = check_for_sync("azure-user", "initial")
+    db_user_payload = check_last_sync("azure-user", "initial")
     if not db_user_payload:
-        LOGGER.info("Inserting AAD data...")
+        LOGGER.info(
+            "No initial AAD user sync was found. Starting initial AAD user sync now."
+        )
 
         LOGGER.info("Getting Users...")
         users = fetch_users()
@@ -232,8 +235,11 @@ def initialize_aad_sync():
                 "An error occurred when uploading users.  Please check the logs."
             )
 
-    db_group_payload = check_for_sync("azure-group", "initial")
+    db_group_payload = check_last_sync("azure-group", "initial")
     if not db_group_payload:
+        LOGGER.info(
+            "No initial AAD group sync was found. Starting initial AAD group sync now."
+        )
         LOGGER.info("Getting Groups with Members...")
         groups = fetch_groups_with_members()
         if groups:

--- a/rbac/providers/common/common.py
+++ b/rbac/providers/common/common.py
@@ -15,9 +15,20 @@
 # limitations under the License.
 # -----------------------------------------------------------------------------
 
+import logging
+import sys
+import time
 from datetime import datetime as dt
 from datetime import timezone
 import rethinkdb as r
+
+from rbac.providers.common.expected_errors import ExpectedError
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.level = logging.INFO
+LOGGER.addHandler(logging.StreamHandler(sys.stdout))
+
+DELAY = 1
 
 
 def save_sync_time(sync_source, sync_type):
@@ -31,11 +42,44 @@ def save_sync_time(sync_source, sync_type):
     r.table("sync_tracker").insert(sync_entry).run()
 
 
-def check_for_sync(source, sync_type):
-    """Check to see if a sync has occurred and return payload."""
-    return (
-        r.table("sync_tracker")
-        .filter({"source": source, "sync_type": sync_type})
-        .coerce_to("array")
-        .run()
-    )
+def get_last_sync(source, sync_type):
+    """
+        Search and get last sync entry from the specified source. Throws
+        ExpectedError if sync_tracker table has not been initialized.
+    """
+    try:
+        last_sync = (
+            r.table("sync_tracker")
+            .filter({"source": source, "sync_type": sync_type})
+            .coerce_to("array")
+            .run()
+        )
+        return last_sync
+    except (r.ReqlOpFailedError, r.ReqlDriverError) as err:
+        raise ExpectedError(err)
+    except Exception as err:
+        LOGGER.warning(type(err).__name__)
+        raise err
+
+
+def check_last_sync(sync_source, sync_type):
+    """
+        Check to see if a sync has occurred and return payload. If the
+        the sync_tracker table is not initialized, this function will
+        keep checking until the table has been initialized.
+    """
+    LOGGER.debug("Checking for previous %s initial sync...", sync_source)
+    while True:
+        try:
+            db_payload = get_last_sync(sync_source, sync_type)
+            return db_payload
+        except ExpectedError:
+            LOGGER.debug(
+                "Sync tracker table has not been initialized. Checking again in %s seconds",
+                DELAY,
+            )
+            time.sleep(DELAY)
+            continue
+        except Exception as err:
+            LOGGER.warning(type(err).__name__)
+            raise err

--- a/rbac/providers/common/expected_errors.py
+++ b/rbac/providers/common/expected_errors.py
@@ -27,11 +27,14 @@ class ExpectedError(Exception):
     recovered from. i.e.: Dropped db connection, uninstantiated table, etc."""
 
     def __init__(self, exception):
-        if exception.__class__.__name__ == r.ReqlNonExistenceError.__class__.__name__:
+        if (
+            exception.__class__.__name__
+            == r.ReqlNonExistenceError("").__class__.__name__
+        ):
             error_message = "The table is empty."
-        elif exception.__class__.__name__ == r.ReqlOpFailedError.__class__.__name__:
+        elif exception.__class__.__name__ == r.ReqlOpFailedError("").__class__.__name__:
             error_message = "The table is not initialized."
-        elif exception.__class__.__name__ == r.ReqlDriverError.__class__.__name__:
+        elif exception.__class__.__name__ == r.ReqlDriverError("").__class__.__name__:
             error_message = "Could not connect to RethinkDB."
         else:
             error_message = exception

--- a/rbac/providers/ldap/ldap_sync.py
+++ b/rbac/providers/ldap/ldap_sync.py
@@ -28,7 +28,7 @@ import ldap3
 from ldap3 import ALL, Connection, Server
 
 from rbac.providers.common import inbound_filters
-from rbac.providers.common.common import save_sync_time, check_for_sync
+from rbac.providers.common.common import save_sync_time, check_last_sync
 from rbac.providers.ldap import ldap_transforms
 
 
@@ -148,8 +148,11 @@ def ldap_sync():
     """Fetches (Users | Groups) from Active Directory and inserts them into RethinkDB."""
 
     if LDAP_DC:
-        db_user_payload = check_for_sync("ldap-user", "initial")
+        db_user_payload = check_last_sync("ldap-user", "initial")
         if not db_user_payload:
+            LOGGER.info(
+                "No initial AD user sync was found. Starting initial AD user sync now."
+            )
             LOGGER.debug("Inserting AD data...")
 
             LOGGER.debug("Getting Users...")
@@ -161,8 +164,11 @@ def ldap_sync():
                 str(int(DELTA_SYNC_INTERVAL_SECONDS)),
             )
 
-        db_group_payload = check_for_sync("ldap-group", "initial")
+        db_group_payload = check_last_sync("ldap-group", "initial")
         if not db_group_payload:
+            LOGGER.info(
+                "No initial AD group sync was found. Starting initial AD group sync now."
+            )
             LOGGER.debug("Getting Groups with Members...")
             fetch_ldap_data(sync_type="initial", data_type="group")
             save_sync_time("ldap-group", "initial")


### PR DESCRIPTION
There was a bug in which both initial syncs were checking sync_tracker
table before it was being initialized. Now, the check will wait until
the table has been initialized.

Also there was a bug with ExpectedError class where it was not
printing properly. That bug was also fixed in this PR.

Signed-off-by: Michael Nguyen <michael.nguyen79@t-mobile.com>