### PR TITLE
Addresser Registry

### DIFF
--- a/rbac/common/addresser/__init__.py
+++ b/rbac/common/addresser/__init__.py
@@ -19,6 +19,11 @@ from rbac.common.addresser.address_space import AddressSpace
 from rbac.common.addresser.address_space import ObjectType
 from rbac.common.addresser.address_space import RelationshipType
 from rbac.common.addresser.address_space import MessageActionType
+from rbac.common.addresser.addressers import get_address_type
+from rbac.common.addresser.addressers import get_addresser
+from rbac.common.addresser.addressers import deserialize
+from rbac.common.addresser.addressers import parse
+from rbac.common.addresser.addressers import parse_addresses
 from rbac.common.addresser.family_address import family
 from rbac.common.user.user_address import USER_ADDRESS as user
 from rbac.common.role.role_address import ROLE_ADDRESS as role
@@ -35,17 +40,6 @@ def address_is(address):
     return get_address_type(address=address)
 
 
-def get_address_type(address):
-    """Returns the address type of the address from AddressSpace"""
-    return (
-        user.get_address_type(address=address)
-        or role.get_address_type(address=address)
-        or task.get_address_type(address=address)
-        or proposal.get_address_type(address=address)
-        or sysadmin.get_address_type(address=address)
-    )
-
-
 __all__ = [
     "AddressSpace",
     "ObjectType",
@@ -53,6 +47,10 @@ __all__ = [
     "MessageActionType",
     "address_is",
     "get_address_type",
+    "get_addresser",
+    "deserialize",
+    "parse",
+    "parse_addresses",
     "family",
     "user",
     "role",

--- a/rbac/common/addresser/addressers.py
+++ b/rbac/common/addresser/addressers.py
@@ -1,0 +1,73 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+"""A registry of addressers; to facilitate root level addresser functions"""
+import logging
+
+LOGGER = logging.getLogger(__name__)
+ADDRESSERS = {}
+
+
+def register_addresser(addresser):
+    """Register the addresser so it can respond to root addresser methods"""
+    ADDRESSERS[addresser.address_type_name] = addresser
+
+
+def get_address_type(address):
+    """Returns the address type of the address from AddressSpace"""
+    for _, addresser in ADDRESSERS.items():
+        result = addresser.get_address_type(address=address)
+        if result:
+            return result
+    raise ValueError(
+        "get_address_type error, no addreser found for address {}".format(
+            parse(address)
+        )
+    )
+
+
+def get_addresser(address):
+    """Returns addresser that handles the address type of given address"""
+    for _, addresser in ADDRESSERS.items():
+        result = addresser.get_addresser(address=address)
+        if result:
+            return result
+    raise ValueError(
+        "get_addresser error, no addreser found for address {}".format(parse(address))
+    )
+
+
+def parse(address):
+    """Parses an address into its components"""
+    for _, addresser in ADDRESSERS.items():
+        result = addresser.parse(address=address)
+        if result:
+            return result
+    raise ValueError("parse error, no addreser found for address {}".format(address))
+
+
+def parse_addresses(addresses):
+    """Parse the given address list into each of their components"""
+    return [parse(address) for address in addresses]
+
+
+def deserialize(address, data):
+    """Deserializes the container of a given an address"""
+    for _, addresser in ADDRESSERS.items():
+        result = addresser.deserialize(address=address, data=data)
+        if result:
+            return result
+    raise ValueError(
+        "deserialize error, no addreser found for address {}".format(parse(address))
+    )

--- a/rbac/common/base/base_relationship.py
+++ b/rbac/common/base/base_relationship.py
@@ -46,6 +46,16 @@ class BaseRelationship(AddressBase):
         raise NotImplementedError("Class must implement this property")
 
     @property
+    def _state_object_name(self):
+        """Task relationship state object name ends with Relationship (TaskRelationship)"""
+        return self._name_camel + "Relationship"
+
+    @property
+    def _state_container_list_name(self):
+        """Tasks relationship state container collection name is relationships"""
+        return "relationships"
+
+    @property
     def _state_container(self):
         """The state container (protobuf) used by this object type
         Derives name of the protobuf class from the object type name

--- a/rbac/common/proposal/proposal_address.py
+++ b/rbac/common/proposal/proposal_address.py
@@ -20,6 +20,10 @@ from rbac.common.base.base_address import AddressBase
 class ProposalAddress(AddressBase):
     """Addresses and accesses proposal objects on the blockchain"""
 
+    def __init__(self):
+        AddressBase.__init__(self)
+        self._register()
+
     @property
     def address_type(self):
         """The address type from AddressSpace implemented by this class"""
@@ -39,6 +43,11 @@ class ProposalAddress(AddressBase):
     def relationship_type(self):
         """The related type from AddressSpace implemented by this class"""
         return addresser.RelationshipType.ATTRIBUTES
+
+    @property
+    def _state_container_prefix(self):
+        """Proposal container is plural (ProposalsContainer)"""
+        return self._state_object_name + "s"
 
 
 PROPOSAL_ADDRESS = ProposalAddress()

--- a/rbac/common/role/relationship_admin.py
+++ b/rbac/common/role/relationship_admin.py
@@ -32,7 +32,7 @@ class AdminRelationship(BaseRelationship):
     """
 
     def __init__(self):
-        BaseRelationship.__init__(self)
+        super().__init__()
         self.propose = ProposeAddRoleAdmin()
         self.confirm = ConfirmAddRoleAdmin()
         self.reject = RejectAddRoleAdmin()

--- a/rbac/common/role/relationship_member.py
+++ b/rbac/common/role/relationship_member.py
@@ -32,7 +32,7 @@ class MemberRelationship(BaseRelationship):
     """
 
     def __init__(self):
-        BaseRelationship.__init__(self)
+        super().__init__()
         self.propose = ProposeAddRoleMember()
         self.confirm = ConfirmAddRoleMember()
         self.reject = RejectAddRoleMember()

--- a/rbac/common/role/relationship_owner.py
+++ b/rbac/common/role/relationship_owner.py
@@ -32,7 +32,7 @@ class OwnerRelationship(BaseRelationship):
     """
 
     def __init__(self):
-        BaseRelationship.__init__(self)
+        super().__init__()
         self.propose = ProposeAddRoleOwner()
         self.confirm = ConfirmAddRoleOwner()
         self.reject = RejectAddRoleOwner()

--- a/rbac/common/role/relationship_task.py
+++ b/rbac/common/role/relationship_task.py
@@ -32,7 +32,7 @@ class TaskRelationship(BaseRelationship):
     """
 
     def __init__(self):
-        BaseRelationship.__init__(self)
+        super().__init__()
         self.propose = ProposeAddRoleTask()
         self.confirm = ConfirmAddRoleTask()
         self.reject = RejectAddRoleTask()

--- a/rbac/common/role/role_address.py
+++ b/rbac/common/role/role_address.py
@@ -15,10 +15,15 @@
 """Addresses and accesses role objects on the blockchain"""
 from rbac.common import addresser
 from rbac.common.base.base_address import AddressBase
+from rbac.common.base.base_relationship import BaseRelationship
 
 
-class RoleOwnerAddress(AddressBase):
+class RoleOwnerAddress(BaseRelationship):
     """Addresses and accesses the role owner relationship"""
+
+    def __init__(self):
+        super().__init__()
+        self._register()
 
     @property
     def address_type(self):
@@ -41,8 +46,12 @@ class RoleOwnerAddress(AddressBase):
         return addresser.RelationshipType.OWNER
 
 
-class RoleAdminAddress(AddressBase):
+class RoleAdminAddress(BaseRelationship):
     """Addresses and accesses the role admin relationship"""
+
+    def __init__(self):
+        super().__init__()
+        self._register()
 
     @property
     def address_type(self):
@@ -65,8 +74,12 @@ class RoleAdminAddress(AddressBase):
         return addresser.RelationshipType.ADMIN
 
 
-class RoleMemberAddress(AddressBase):
+class RoleMemberAddress(BaseRelationship):
     """Addresses and accesses the role member relationship"""
+
+    def __init__(self):
+        super().__init__()
+        self._register()
 
     @property
     def address_type(self):
@@ -89,8 +102,12 @@ class RoleMemberAddress(AddressBase):
         return addresser.RelationshipType.MEMBER
 
 
-class RoleTaskAddress(AddressBase):
+class RoleTaskAddress(BaseRelationship):
     """Addresses and accesses the role task relationship"""
+
+    def __init__(self):
+        super().__init__()
+        self._register()
 
     @property
     def address_type(self):
@@ -117,7 +134,8 @@ class RoleAddress(AddressBase):
     """Addresses and accesses role objects on the blockchain"""
 
     def __init__(self):
-        AddressBase.__init__(self)
+        super().__init__()
+        self._register()
         self.owner = RoleOwnerAddress()
         self.admin = RoleAdminAddress()
         self.member = RoleMemberAddress()
@@ -143,16 +161,15 @@ class RoleAddress(AddressBase):
         """The related type from AddressSpace implemented by this class"""
         return addresser.RelationshipType.ATTRIBUTES
 
-    def get_address_type(self, address):
-        """Returns the address type if the address is of the address type
-        implemented by this class or a child class, otherewise returns None"""
-        return (
-            self.address_is(address=address)
-            or self.owner.get_address_type(address=address)
-            or self.admin.get_address_type(address=address)
-            or self.member.get_address_type(address=address)
-            or self.task.get_address_type(address=address)
-        )
+    @property
+    def _state_object_name(self):
+        """Tasks state object name ends with Attributes (TaskAttributes)"""
+        return self._name_camel + "Attributes"
+
+    @property
+    def _state_container_list_name(self):
+        """Tasks state container collection name contains _attributes (task_attributes)"""
+        return self._name_lower + "_attributes"
 
 
 ROLE_ADDRESS = RoleAddress()

--- a/rbac/common/sysadmin/sysadmin_address.py
+++ b/rbac/common/sysadmin/sysadmin_address.py
@@ -20,6 +20,10 @@ from rbac.common.base.base_address import AddressBase
 class SysAdminOwnerAddress(AddressBase):
     """Addresses and accesses the sysadmin owner relationship"""
 
+    def __init__(self):
+        AddressBase.__init__(self)
+        self._register()
+
     @property
     def address_type(self):
         """The address type from AddressSpace implemented by this class"""
@@ -44,6 +48,10 @@ class SysAdminOwnerAddress(AddressBase):
 class SysAdminAdminAddress(AddressBase):
     """Addresses and accesses the sysadmin admin relationship"""
 
+    def __init__(self):
+        AddressBase.__init__(self)
+        self._register()
+
     @property
     def address_type(self):
         """The address type from AddressSpace implemented by this class"""
@@ -67,6 +75,10 @@ class SysAdminAdminAddress(AddressBase):
 
 class SysAdminMemberAddress(AddressBase):
     """Addresses and accesses the sysadmin member relationship"""
+
+    def __init__(self):
+        AddressBase.__init__(self)
+        self._register()
 
     @property
     def address_type(self):
@@ -94,6 +106,7 @@ class SysAdminAddress(AddressBase):
 
     def __init__(self):
         AddressBase.__init__(self)
+        self._register()
         self.owner = SysAdminOwnerAddress()
         self.admin = SysAdminAdminAddress()
         self.member = SysAdminMemberAddress()
@@ -122,16 +135,6 @@ class SysAdminAddress(AddressBase):
         """Makes a blockchain address of this address type
         (sysadmin has no object_id, there is only one sysadmin role)"""
         return self._address(object_id=object_id, target_id=target_id)
-
-    def get_address_type(self, address):
-        """Returns the address type if the address is of the address type
-        implemented by this class or a child class, otherewise returns None"""
-        return (
-            self.address_is(address=address)
-            or self.owner.get_address_type(address=address)
-            or self.admin.get_address_type(address=address)
-            or self.member.get_address_type(address=address)
-        )
 
 
 SYSADMIN_ADDRESS = SysAdminAddress()

--- a/rbac/common/task/relationship_admin.py
+++ b/rbac/common/task/relationship_admin.py
@@ -32,7 +32,7 @@ class AdminRelationship(BaseRelationship):
     """
 
     def __init__(self):
-        BaseRelationship.__init__(self)
+        super().__init__()
         self.propose = ProposeAddTaskAdmin()
         self.confirm = ConfirmAddTaskAdmin()
         self.reject = RejectAddTaskAdmin()

--- a/rbac/common/task/relationship_owner.py
+++ b/rbac/common/task/relationship_owner.py
@@ -32,7 +32,7 @@ class OwnerRelationship(BaseRelationship):
     """
 
     def __init__(self):
-        BaseRelationship.__init__(self)
+        super().__init__()
         self.propose = ProposeAddTaskOwner()
         self.confirm = ConfirmAddTaskOwner()
         self.reject = RejectAddTaskOwner()

--- a/rbac/common/task/task_address.py
+++ b/rbac/common/task/task_address.py
@@ -15,10 +15,15 @@
 """Addresses and accesses task objects on the blockchain"""
 from rbac.common import addresser
 from rbac.common.base.base_address import AddressBase
+from rbac.common.base.base_relationship import BaseRelationship
 
 
-class TaskOwnerAddress(AddressBase):
+class TaskOwnerAddress(BaseRelationship):
     """Addresses and accesses the role owner relationship"""
+
+    def __init__(self):
+        super().__init__()
+        self._register()
 
     @property
     def address_type(self):
@@ -41,8 +46,12 @@ class TaskOwnerAddress(AddressBase):
         return addresser.RelationshipType.OWNER
 
 
-class TaskAdminAddress(AddressBase):
+class TaskAdminAddress(BaseRelationship):
     """Addresses and accesses the role admin relationship"""
+
+    def __init__(self):
+        super().__init__()
+        self._register()
 
     @property
     def address_type(self):
@@ -69,7 +78,8 @@ class TaskAddress(AddressBase):
     """Addresses and accesses task objects on the blockchain"""
 
     def __init__(self):
-        AddressBase.__init__(self)
+        super().__init__()
+        self._register()
         self.owner = TaskOwnerAddress()
         self.admin = TaskAdminAddress()
 
@@ -94,18 +104,14 @@ class TaskAddress(AddressBase):
         return addresser.RelationshipType.ATTRIBUTES
 
     @property
-    def _state_container_prefix(self):
-        """Tasks state container name contains Attributes (TaskAttributesContainer)"""
+    def _state_object_name(self):
+        """Tasks state object name ends with Attributes (TaskAttributes)"""
         return self._name_camel + "Attributes"
 
-    def get_address_type(self, address):
-        """Returns the address type if the address is of the address type
-        implemented by this class or a child class, otherewise returns None"""
-        return (
-            self.address_is(address=address)
-            or self.owner.get_address_type(address=address)
-            or self.admin.get_address_type(address=address)
-        )
+    @property
+    def _state_container_list_name(self):
+        """Tasks state container collection name contains _attributes (task_attributes)"""
+        return self._name_lower + "_attributes"
 
 
 TASK_ADDRESS = TaskAddress()

--- a/rbac/common/user/user_address.py
+++ b/rbac/common/user/user_address.py
@@ -20,6 +20,10 @@ from rbac.common.base.base_address import AddressBase
 class UserAddress(AddressBase):
     """Addresses and accesses user objects on the blockchain"""
 
+    def __init__(self):
+        AddressBase.__init__(self)
+        self._register()
+
     @property
     def address_type(self):
         """The address type from AddressSpace implemented by this class"""

--- a/tests/rbac/common/addresser/role_test.py
+++ b/tests/rbac/common/addresser/role_test.py
@@ -36,6 +36,34 @@ class TestRoleAddresser(TestAssertions):
             addresser.address_is(role_address), addresser.AddressSpace.ROLES_ATTRIBUTES
         )
 
+    def test_get_address_type(self):
+        """Tests that get_address_type returns AddressSpace.USER if it is a role
+        address, and None if it is of another address type"""
+        role_address = addresser.role.address(addresser.role.unique_id())
+        other_address = addresser.user.address(addresser.user.unique_id())
+        self.assertEqual(
+            addresser.get_address_type(role_address),
+            addresser.AddressSpace.ROLES_ATTRIBUTES,
+        )
+        self.assertEqual(
+            addresser.role.get_address_type(role_address),
+            addresser.AddressSpace.ROLES_ATTRIBUTES,
+        )
+        self.assertIsNone(addresser.role.get_address_type(other_address))
+
+    def test_addresses_are(self):
+        """Test that addresses_are returns True if all addresses are a role
+        addresses, and False if any addresses are if a different address type"""
+        role_address1 = addresser.role.address(addresser.role.unique_id())
+        role_address2 = addresser.role.address(addresser.role.unique_id())
+        other_address = addresser.user.address(addresser.user.unique_id())
+        self.assertTrue(addresser.role.addresses_are([role_address1]))
+        self.assertTrue(addresser.role.addresses_are([role_address1, role_address2]))
+        self.assertFalse(addresser.role.addresses_are([other_address]))
+        self.assertFalse(addresser.role.addresses_are([role_address1, other_address]))
+        self.assertFalse(addresser.role.addresses_are([other_address, role_address1]))
+        self.assertTrue(addresser.role.addresses_are([]))
+
     def test_address_deterministic(self):
         """Tests address makes an address that identifies as the correct AddressSpace"""
         role_id1 = addresser.role.unique_id()

--- a/tests/rbac/common/addresser/user_test.py
+++ b/tests/rbac/common/addresser/user_test.py
@@ -64,30 +64,74 @@ class TestUserAddresser(TestAssertions):
         """Tests that get_address_type returns AddressSpace.USER if it is a user
         address, and None if it is of another address type"""
         user_address = addresser.user.address(addresser.user.unique_id())
-        role_address = addresser.role.address(addresser.role.unique_id())
+        other_address = addresser.role.address(addresser.role.unique_id())
         self.assertEqual(
             addresser.get_address_type(user_address), addresser.AddressSpace.USER
         )
         self.assertEqual(
             addresser.user.get_address_type(user_address), addresser.AddressSpace.USER
         )
-        self.assertIsNone(addresser.user.get_address_type(role_address))
-        self.assertEqual(
-            addresser.get_address_type(role_address),
-            addresser.AddressSpace.ROLES_ATTRIBUTES,
+        self.assertIsNone(addresser.user.get_address_type(other_address))
+
+    def test_get_addresser(self):
+        """Test that get_addresser returns the addresser class if it is a
+        user address, and None if it is of another address type"""
+        user_address = addresser.user.address(addresser.user.unique_id())
+        other_address = addresser.role.address(addresser.role.unique_id())
+        self.assertIsInstance(
+            addresser.get_addresser(user_address), type(addresser.user)
         )
+        self.assertIsInstance(
+            addresser.user.get_addresser(user_address), type(addresser.user)
+        )
+        self.assertIsNone(addresser.user.get_addresser(other_address))
+
+    def test_user_parse(self):
+        """Test addresser.user.parse returns a parsed address if it is a user address"""
+        user_id = addresser.user.unique_id()
+        user_address = addresser.user.address(user_id)
+        parsed = addresser.user.parse(user_address)
+
+        self.assertEqual(parsed.object_type, addresser.ObjectType.USER)
+        self.assertEqual(parsed.related_type, addresser.ObjectType.SELF)
+        self.assertEqual(
+            parsed.relationship_type, addresser.RelationshipType.ATTRIBUTES
+        )
+        self.assertEqual(parsed.address_type, addresser.AddressSpace.USER)
+        self.assertEqual(parsed.object_id, user_id)
+        self.assertEqual(parsed.target_id, None)
+
+    def test_addresser_parse(self):
+        """Test addresser.parse returns a parsed address"""
+        user_id = addresser.user.unique_id()
+        user_address = addresser.user.address(user_id)
+        parsed = addresser.parse(user_address)
+
+        self.assertEqual(parsed.object_type, addresser.ObjectType.USER)
+        self.assertEqual(parsed.related_type, addresser.ObjectType.SELF)
+        self.assertEqual(
+            parsed.relationship_type, addresser.RelationshipType.ATTRIBUTES
+        )
+        self.assertEqual(parsed.address_type, addresser.AddressSpace.USER)
+        self.assertEqual(parsed.object_id, user_id)
+        self.assertEqual(parsed.target_id, None)
+
+    def test_parse_other(self):
+        """Test that parse returns None if it is not a user address"""
+        other_address = addresser.role.address(addresser.role.unique_id())
+        self.assertIsNone(addresser.user.parse(other_address))
 
     def test_addresses_are(self):
         """Test that addresses_are returns True if all addresses are a user
         addresses, and False if any addresses are if a different address type"""
         user_address1 = addresser.user.address(addresser.user.unique_id())
         user_address2 = addresser.user.address(addresser.user.unique_id())
-        role_address = addresser.role.address(addresser.role.unique_id())
+        other_address = addresser.role.address(addresser.role.unique_id())
         self.assertTrue(addresser.user.addresses_are([user_address1]))
         self.assertTrue(addresser.user.addresses_are([user_address1, user_address2]))
-        self.assertFalse(addresser.user.addresses_are([role_address]))
-        self.assertFalse(addresser.user.addresses_are([user_address1, role_address]))
-        self.assertFalse(addresser.user.addresses_are([role_address, user_address1]))
+        self.assertFalse(addresser.user.addresses_are([other_address]))
+        self.assertFalse(addresser.user.addresses_are([user_address1, other_address]))
+        self.assertFalse(addresser.user.addresses_are([other_address, user_address1]))
         self.assertTrue(addresser.user.addresses_are([]))
 
     def test_address_deterministic(self):


### PR DESCRIPTION
Add address parse, deserialization, get_address_type, and
an addresser registry to facilitate root level addresser
methods for these functions.

Also adds some container name hints.

Task for Issue #210 and #552