### PR TITLE
AAD inbound/outbound sync multithreading

### DIFF
--- a/bin/rbac-providers-azure
+++ b/bin/rbac-providers-azure
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 # Copyright 2018 Contributors to Hyperledger Sawtooth
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +16,9 @@
 
 import os
 import sys
+import threading
+import time
+import logging
 
 TOP_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, TOP_DIR)
@@ -25,7 +27,46 @@ from rbac.providers.azure.initial_inbound_sync import initialize_aad_sync
 from rbac.providers.azure.delta_outbound_sync import outbound_sync_listener
 from rbac.providers.azure.delta_inbound_sync import inbound_sync_listener
 
+# LOGGER levels: info, debug, warning, exception, error
+logging.basicConfig(level=logging.INFO)
+LOGGER = logging.getLogger(__name__)
+
+
+class InboundSyncThread(threading.Thread):
+    """Custom Thread subclass that runs an AAD inbound sync listener in its own
+    thread."""
+    def __init__(self):
+        """Initialize the InboundSyncThread class"""
+        threading.Thread.__init__(self)
+        self.name = "AAD Inbound Delta Sync Thread"
+
+    def run(self):
+        """Start the InboundSyncThread"""
+        LOGGER.info("Starting %s", self.name)
+        inbound_sync_listener()
+        LOGGER.info("Exiting %s", self.name)
+
+
+class OutboundSyncThread(threading.Thread):
+    """Custom Thread subclass that runs an AAD outbound sync listener in its own
+    thread."""
+    def __init__(self):
+        """Initialize the OutboundSyncThread class"""
+        threading.Thread.__init__(self)
+        self.name = "AAD Outbound Delta Sync Thread"
+
+    def run(self):
+        """Start the OutboundSyncThread"""
+        LOGGER.info("Starting %s", self.name)
+        outbound_sync_listener()
+        LOGGER.info("Exiting %s", self.name)
+
+
 if __name__ == "__main__":
     initialize_aad_sync()
-    inbound_sync_listener()
-    outbound_sync_listener()
+    # Create sync listener threads.
+    inbound_sync_thread = InboundSyncThread()
+    outbound_sync_thread = OutboundSyncThread()
+    # Start sync listener threads.
+    inbound_sync_thread.start()
+    outbound_sync_thread.start()

--- a/rbac/providers/azure/delta_inbound_sync.py
+++ b/rbac/providers/azure/delta_inbound_sync.py
@@ -64,6 +64,7 @@ VALID_OPERATIONS = {
 
 
 def inbound_sync_listener():
+    """Initialize a delta inbound sync with Azure Active Directory."""
     while True:  # pylint: disable=too-many-nested-blocks
         provider_id = TENANT_ID
         try:
@@ -154,7 +155,7 @@ def insert_change_to_db(data, record_timestamp):
         "timestamp": record_timestamp,
         "provider_id": TENANT_ID,
     }
-    response = r.table("queue_inbound").insert(inbound_entry).run()
+    r.table("queue_inbound").insert(inbound_entry).run()
 
 
 def get_last_delta_sync(provider_id, sync_type):


### PR DESCRIPTION
Add multithreading to AAD daemon to allow inbound and outbound syncs to run
in parallel.

[Ticket #664]

Signed-off-by: jbobo <j.ned@bobonana.me>