### PR TITLE
Client Dockerfile Build

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -153,8 +153,8 @@ services:
       - CHOKIDAR_USEPOLLING=true
     image: rbac-client:${ISOLATION_ID-latest}
     volumes:
-      - "./client/src:/client/src"
-      - "./client/public:/client/public"
+      - ./client:/client
+      - /client/node_modules
     ports:
       - "4201:3000"
       - "35729:35729"

--- a/docker/client.Dockerfile
+++ b/docker/client.Dockerfile
@@ -16,13 +16,13 @@
 
 FROM node:8
 
-WORKDIR /tmp
-COPY ./client/package.json ./client/yarn.lock ./client/.yarnrc ./
-RUN yarn
-
 WORKDIR /client
-RUN cp -a /tmp/node_modules .
-COPY ./client .
+
+COPY ./client/package.json ./client/yarn.lock ./client/semantic.json ./
+RUN yarn global add gulp@4.0 \
+ && yarn install
+
+COPY ./client/src/semantic ./src/semantic
 RUN yarn build:semantic
 
 CMD ["./entrypoint.sh"]


### PR DESCRIPTION
Mounts local files
Excludes node_modules from mount
Installs dependencies in docker cache layer
Builds semantic in docker cache layer

Fixes errors encountered building the client docker container
Rebuild the client container via ```docker-compose build rbac-client```
