### PR TITLE
Rename target_id to related_id

### DIFF
--- a/rbac/common/base/base_address.py
+++ b/rbac/common/base/base_address.py
@@ -40,7 +40,7 @@ class Address:
         object_id,
         related_type,
         relationship_type,
-        target_id,
+        related_id,
     ):
         self._address = address
         self._address_type = address_type
@@ -48,7 +48,7 @@ class Address:
         self._object_id = object_id
         self._related_type = related_type
         self._relationship_type = relationship_type
-        self._target_id = target_id
+        self._related_id = related_id
 
     @property
     def address(self):
@@ -82,11 +82,11 @@ class Address:
         return self._relationship_type
 
     @property
-    def target_id(self):
-        """The hash of a target_id (the target_id
+    def related_id(self):
+        """The hash of a related_id (the related_id
         itself if it is a 12-byte unique identifier)
-        None if no target_id."""
-        return self._target_id
+        None if no related_id."""
+        return self._related_id
 
     def __repr__(self):
         """Return a string representation of the object"""
@@ -98,7 +98,7 @@ class Address:
                 "object_id": self.object_id,
                 "related_type": self.related_type.name,
                 "relationship_type": self.relationship_type.name,
-                "target_id": self.target_id,
+                "related_id": self.related_id,
             }
         )
 
@@ -132,7 +132,7 @@ class AddressBase(StateBase):
             + r"$"
         )
 
-    def _address(self, object_id, target_id):
+    def _address(self, object_id, related_id):
         """Makes an address using the address scheme"""
         address = (
             family.namespace
@@ -141,7 +141,7 @@ class AddressBase(StateBase):
             + self.hash(object_id)
             + hex(self.related_type.value)[2:].zfill(4)
             + hex(self.relationship_type.value)[2:].zfill(2)
-            + self.hash(target_id)
+            + self.hash(related_id)
             + PATTERN_ZERO_BYTE
         )
         return address
@@ -157,7 +157,7 @@ class AddressBase(StateBase):
                 object_id=self.get_object_id(address=address),
                 related_type=self.related_type,
                 relationship_type=self.relationship_type,
-                target_id=self.get_target_id(address=address),
+                related_id=self.get_related_id(address=address),
             )
         return None
 
@@ -204,9 +204,9 @@ class AddressBase(StateBase):
             + self.relationship_type.name
         )
 
-    def address(self, object_id, target_id=None):
+    def address(self, object_id, related_id=None):
         """Makes a blockchain address of this address type"""
-        return self._address(object_id=object_id, target_id=target_id)
+        return self._address(object_id=object_id, related_id=related_id)
 
     def address_is(self, address):
         """Returns the address type if the address is of the address type
@@ -238,8 +238,8 @@ class AddressBase(StateBase):
         is a 12-byte unique identifier), as encoded in a given address"""
         return address[14:38]
 
-    def get_target_id(self, address):
-        """Returns the hash of a target_id (or the target_id itself if it
+    def get_related_id(self, address):
+        """Returns the hash of a related_id (or the related_id itself if it
         is a 12-byte unique identifier), as encoded in a given address"""
         value = address[44:68]
         if value == PATTERN_ZERO_BYTE * 12:

--- a/rbac/common/base/base_relationship.py
+++ b/rbac/common/base/base_relationship.py
@@ -79,11 +79,11 @@ class BaseRelationship(AddressBase):
             self._name_camel + "RelationshipContainer",
         )
 
-    def exists(self, object_id, target_id):
+    def exists(self, object_id, related_id):
         """Check the existence of a relationship record"""
         # pylint: disable=not-callable
         container = self._state_container()
-        address = self.address(object_id=object_id, target_id=target_id)
+        address = self.address(object_id=object_id, related_id=related_id)
         container.ParseFromString(client.get_address(address=address))
         items = list(container.relationships)
         if not items:
@@ -94,7 +94,7 @@ class BaseRelationship(AddressBase):
                 self.object_type.name.title(),
                 object_id,
                 self.related_type.name.lower(),
-                target_id,
+                related_id,
                 address,
             )
         item = items[0]
@@ -105,7 +105,7 @@ class BaseRelationship(AddressBase):
                 self.object_type.name.title(),
                 object_id,
                 self.related_type.name.lower(),
-                target_id,
+                related_id,
                 address,
             )
             return False
@@ -115,7 +115,7 @@ class BaseRelationship(AddressBase):
                 self.object_type.name.title(),
                 object_id,
                 self.related_type.name.lower(),
-                target_id,
+                related_id,
                 address,
             )
-        return bool(target_id in item.identifiers)
+        return bool(related_id in item.identifiers)

--- a/rbac/common/proposal/proposal_confirm.py
+++ b/rbac/common/proposal/proposal_confirm.py
@@ -36,7 +36,7 @@ class ProposalConfirm(ProposalAction):
         raise NotImplementedError("Class must implement this method")
 
     def store_message(
-        self, object_id, target_id, store, message, outputs, output_state, signer
+        self, object_id, related_id, store, message, outputs, output_state, signer
     ):
         """Update the proposal data"""
         # pylint: disable=no-member

--- a/rbac/common/proposal/proposal_propose.py
+++ b/rbac/common/proposal/proposal_propose.py
@@ -49,7 +49,7 @@ class ProposalPropose(ProposalMessage):
             signer=signer,
         )
         object_id = self._get_object_id(message)
-        target_id = self._get_target_id(message)
+        related_id = self._get_related_id(message)
         if hasattr(message, "user_id") and getattr(message, "user_id") != signer:
             user = addresser.user.get_from_input_state(
                 inputs=inputs, input_state=input_state, object_id=message.user_id
@@ -64,7 +64,7 @@ class ProposalPropose(ProposalMessage):
             inputs=inputs,
             input_state=input_state,
             object_id=object_id,
-            target_id=target_id,
+            related_id=related_id,
         )
         if (
             # pylint: disable=no-member
@@ -76,13 +76,13 @@ class ProposalPropose(ProposalMessage):
                     last_proposal.proposal_id,
                     self._name_id,
                     object_id,
-                    self._target_id,
-                    target_id,
+                    self._related_id,
+                    related_id,
                 )
             )
 
     def store_message(
-        self, object_id, target_id, store, message, outputs, output_state, signer
+        self, object_id, related_id, store, message, outputs, output_state, signer
     ):
         """Create the proposal data"""
         store.proposal_id = message.proposal_id
@@ -90,7 +90,7 @@ class ProposalPropose(ProposalMessage):
         # pylint: disable=no-member
         store.status = protobuf.proposal_state_pb2.Proposal.OPEN
         store.object_id = self._get_object_id(message)
-        store.target_id = self._get_target_id(message)
+        store.related_id = self._get_related_id(message)
         store.open_reason = message.reason
         store.opener = signer
         # store.metadata = message.metadata

--- a/rbac/common/proposal/proposal_reject.py
+++ b/rbac/common/proposal/proposal_reject.py
@@ -36,7 +36,7 @@ class ProposalReject(ProposalAction):
         raise NotImplementedError("Class must implement this method")
 
     def store_message(
-        self, object_id, target_id, store, message, outputs, output_state, signer
+        self, object_id, related_id, store, message, outputs, output_state, signer
     ):
         """Update the proposal data"""
         # pylint: disable=no-member

--- a/rbac/common/proposal/proposal_state.proto
+++ b/rbac/common/proposal/proposal_state.proto
@@ -54,15 +54,15 @@ message Proposal {
     ProposalType proposal_type = 2;
 
 
-    // The id of the Role, Task, User that the 'target_id' is being added or
+    // The id of the Role, Task, User that the 'related_id' is being added or
     // removed from. For example, for an ADD_ROLE_MEMBER Proposal, the
     // object_id is the Role id.
     string object_id = 3;
 
     // The id of the Task, or User that is being added or removed from the
     // 'object_id'. For example, for an ADD_TASK_OWNER Proposal, the
-    // target_id is the User id of the proposed new Owner.
-    string target_id = 4;
+    // related_id is the User id of the proposed new Owner.
+    string related_id = 4;
 
     // The public key of the user that caused the Proposal to be created.
     string opener = 5;

--- a/rbac/common/protobuf/proposal_state_pb2.py
+++ b/rbac/common/protobuf/proposal_state_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\x14proposal_state.proto\"2\n\x12ProposalsContainer\x12\x1c\n\tproposals\x18\x01 \x03(\x0b\x32\t.Proposal\"\x8e\x05\n\x08Proposal\x12\x13\n\x0bproposal_id\x18\x01 \x01(\t\x12-\n\rproposal_type\x18\x02 \x01(\x0e\x32\x16.Proposal.ProposalType\x12\x11\n\tobject_id\x18\x03 \x01(\t\x12\x11\n\ttarget_id\x18\x04 \x01(\t\x12\x0e\n\x06opener\x18\x05 \x01(\t\x12\x0e\n\x06\x63loser\x18\x06 \x01(\t\x12 \n\x06status\x18\x07 \x01(\x0e\x32\x10.Proposal.Status\x12\x13\n\x0bopen_reason\x18\x08 \x01(\t\x12\x14\n\x0c\x63lose_reason\x18\t \x01(\t\x12\x10\n\x08metadata\x18\n \x01(\t\x12\x1c\n\tapprovals\x18\x0b \x03(\x0b\x32\t.Approval\x12\x1e\n\nrejections\x18\x0c \x03(\x0b\x32\n.Rejection\"\xa9\x02\n\x0cProposalType\x12\x11\n\rADD_ROLE_TASK\x10\x00\x12\x13\n\x0f\x41\x44\x44_ROLE_MEMBER\x10\x01\x12\x12\n\x0e\x41\x44\x44_ROLE_OWNER\x10\x02\x12\x12\n\x0e\x41\x44\x44_ROLE_ADMIN\x10\x03\x12\x14\n\x10REMOVE_ROLE_TASK\x10\x04\x12\x16\n\x12REMOVE_ROLE_MEMBER\x10\x05\x12\x15\n\x11REMOVE_ROLE_OWNER\x10\x06\x12\x15\n\x11REMOVE_ROLE_ADMIN\x10\x07\x12\x12\n\x0e\x41\x44\x44_TASK_OWNER\x10\x08\x12\x12\n\x0e\x41\x44\x44_TASK_ADMIN\x10\t\x12\x15\n\x11REMOVE_TASK_OWNER\x10\n\x12\x15\n\x11REMOVE_TASK_ADMIN\x10\x0b\x12\x17\n\x13UPDATE_USER_MANAGER\x10\x0c\"/\n\x06Status\x12\x08\n\x04OPEN\x10\x00\x12\x0c\n\x08REJECTED\x10\x01\x12\r\n\tCONFIRMED\x10\x02\"/\n\x08\x41pproval\x12\x10\n\x08\x61pprover\x18\x01 \x01(\t\x12\x11\n\ton_behalf\x18\x02 \x01(\t\"0\n\tRejection\x12\x10\n\x08rejector\x18\x01 \x01(\t\x12\x11\n\ton_behalf\x18\x02 \x01(\tb\x06proto3')
+  serialized_pb=_b('\n\x14proposal_state.proto\"2\n\x12ProposalsContainer\x12\x1c\n\tproposals\x18\x01 \x03(\x0b\x32\t.Proposal\"\x8f\x05\n\x08Proposal\x12\x13\n\x0bproposal_id\x18\x01 \x01(\t\x12-\n\rproposal_type\x18\x02 \x01(\x0e\x32\x16.Proposal.ProposalType\x12\x11\n\tobject_id\x18\x03 \x01(\t\x12\x12\n\nrelated_id\x18\x04 \x01(\t\x12\x0e\n\x06opener\x18\x05 \x01(\t\x12\x0e\n\x06\x63loser\x18\x06 \x01(\t\x12 \n\x06status\x18\x07 \x01(\x0e\x32\x10.Proposal.Status\x12\x13\n\x0bopen_reason\x18\x08 \x01(\t\x12\x14\n\x0c\x63lose_reason\x18\t \x01(\t\x12\x10\n\x08metadata\x18\n \x01(\t\x12\x1c\n\tapprovals\x18\x0b \x03(\x0b\x32\t.Approval\x12\x1e\n\nrejections\x18\x0c \x03(\x0b\x32\n.Rejection\"\xa9\x02\n\x0cProposalType\x12\x11\n\rADD_ROLE_TASK\x10\x00\x12\x13\n\x0f\x41\x44\x44_ROLE_MEMBER\x10\x01\x12\x12\n\x0e\x41\x44\x44_ROLE_OWNER\x10\x02\x12\x12\n\x0e\x41\x44\x44_ROLE_ADMIN\x10\x03\x12\x14\n\x10REMOVE_ROLE_TASK\x10\x04\x12\x16\n\x12REMOVE_ROLE_MEMBER\x10\x05\x12\x15\n\x11REMOVE_ROLE_OWNER\x10\x06\x12\x15\n\x11REMOVE_ROLE_ADMIN\x10\x07\x12\x12\n\x0e\x41\x44\x44_TASK_OWNER\x10\x08\x12\x12\n\x0e\x41\x44\x44_TASK_ADMIN\x10\t\x12\x15\n\x11REMOVE_TASK_OWNER\x10\n\x12\x15\n\x11REMOVE_TASK_ADMIN\x10\x0b\x12\x17\n\x13UPDATE_USER_MANAGER\x10\x0c\"/\n\x06Status\x12\x08\n\x04OPEN\x10\x00\x12\x0c\n\x08REJECTED\x10\x01\x12\r\n\tCONFIRMED\x10\x02\"/\n\x08\x41pproval\x12\x10\n\x08\x61pprover\x18\x01 \x01(\t\x12\x11\n\ton_behalf\x18\x02 \x01(\t\"0\n\tRejection\x12\x10\n\x08rejector\x18\x01 \x01(\t\x12\x11\n\ton_behalf\x18\x02 \x01(\tb\x06proto3')
 )
 
 
@@ -85,8 +85,8 @@ _PROPOSAL_PROPOSALTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=385,
-  serialized_end=682,
+  serialized_start=386,
+  serialized_end=683,
 )
 _sym_db.RegisterEnumDescriptor(_PROPOSAL_PROPOSALTYPE)
 
@@ -111,8 +111,8 @@ _PROPOSAL_STATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=684,
-  serialized_end=731,
+  serialized_start=685,
+  serialized_end=732,
 )
 _sym_db.RegisterEnumDescriptor(_PROPOSAL_STATUS)
 
@@ -177,7 +177,7 @@ _PROPOSAL = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='target_id', full_name='Proposal.target_id', index=3,
+      name='related_id', full_name='Proposal.related_id', index=3,
       number=4, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -254,7 +254,7 @@ _PROPOSAL = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=77,
-  serialized_end=731,
+  serialized_end=732,
 )
 
 
@@ -291,8 +291,8 @@ _APPROVAL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=733,
-  serialized_end=780,
+  serialized_start=734,
+  serialized_end=781,
 )
 
 
@@ -329,8 +329,8 @@ _REJECTION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=782,
-  serialized_end=830,
+  serialized_start=783,
+  serialized_end=831,
 )
 
 _PROPOSALSCONTAINER.fields_by_name['proposals'].message_type = _PROPOSAL

--- a/rbac/common/role/confirm_admin.py
+++ b/rbac/common/role/confirm_admin.py
@@ -68,7 +68,7 @@ class ConfirmAddRoleAdmin(ProposalConfirm):
         )
 
         proposal_address = self.address(
-            object_id=message.role_id, target_id=message.user_id
+            object_id=message.role_id, related_id=message.user_id
         )
 
         inputs = [
@@ -97,7 +97,7 @@ class ConfirmAddRoleAdmin(ProposalConfirm):
             inputs=inputs,
             input_state=input_state,
             object_id=message.role_id,
-            target_id=signer,
+            related_id=signer,
         ):
             raise ValueError(
                 "Signer {} must be an admin of the role {}".format(
@@ -106,12 +106,12 @@ class ConfirmAddRoleAdmin(ProposalConfirm):
             )
 
     def apply_update(
-        self, message, object_id, target_id, outputs, output_state, signer
+        self, message, object_id, related_id, outputs, output_state, signer
     ):
         """Create admin address"""
         addresser.role.admin.create_relationship(
             object_id=object_id,
-            target_id=target_id,
+            related_id=related_id,
             outputs=outputs,
             output_state=output_state,
         )

--- a/rbac/common/role/confirm_member.py
+++ b/rbac/common/role/confirm_member.py
@@ -72,7 +72,7 @@ class ConfirmAddRoleMember(ProposalConfirm):
         )
 
         proposal_address = self.address(
-            object_id=message.role_id, target_id=message.user_id
+            object_id=message.role_id, related_id=message.user_id
         )
 
         inputs = [
@@ -102,7 +102,7 @@ class ConfirmAddRoleMember(ProposalConfirm):
             inputs=inputs,
             input_state=input_state,
             object_id=message.role_id,
-            target_id=signer,
+            related_id=signer,
         ):
             raise ValueError(
                 "Signer {} must be an owner of the role {}".format(
@@ -111,12 +111,12 @@ class ConfirmAddRoleMember(ProposalConfirm):
             )
 
     def apply_update(
-        self, message, object_id, target_id, outputs, output_state, signer
+        self, message, object_id, related_id, outputs, output_state, signer
     ):
         """Create admin address"""
         addresser.role.member.create_relationship(
             object_id=object_id,
-            target_id=target_id,
+            related_id=related_id,
             outputs=outputs,
             output_state=output_state,
         )

--- a/rbac/common/role/confirm_owner.py
+++ b/rbac/common/role/confirm_owner.py
@@ -72,7 +72,7 @@ class ConfirmAddRoleOwner(ProposalConfirm):
         )
 
         proposal_address = self.address(
-            object_id=message.role_id, target_id=message.user_id
+            object_id=message.role_id, related_id=message.user_id
         )
 
         inputs = [
@@ -103,7 +103,7 @@ class ConfirmAddRoleOwner(ProposalConfirm):
             inputs=inputs,
             input_state=input_state,
             object_id=message.role_id,
-            target_id=signer,
+            related_id=signer,
         ):
             raise ValueError(
                 "Signer {} must be an admin of the role {}\n{}".format(
@@ -112,12 +112,12 @@ class ConfirmAddRoleOwner(ProposalConfirm):
             )
 
     def apply_update(
-        self, message, object_id, target_id, outputs, output_state, signer
+        self, message, object_id, related_id, outputs, output_state, signer
     ):
         """Create admin address"""
         addresser.role.owner.create_relationship(
             object_id=object_id,
-            target_id=target_id,
+            related_id=related_id,
             outputs=outputs,
             output_state=output_state,
         )

--- a/rbac/common/role/confirm_task.py
+++ b/rbac/common/role/confirm_task.py
@@ -67,7 +67,7 @@ class ConfirmAddRoleTask(ProposalConfirm):
         )
 
         proposal_address = self.address(
-            object_id=message.role_id, target_id=message.task_id
+            object_id=message.role_id, related_id=message.task_id
         )
 
         inputs = [
@@ -95,7 +95,7 @@ class ConfirmAddRoleTask(ProposalConfirm):
             inputs=inputs,
             input_state=input_state,
             object_id=message.task_id,
-            target_id=signer,
+            related_id=signer,
         ):
             raise ValueError(
                 "Signer {} must be an owner of the task {}".format(
@@ -104,12 +104,12 @@ class ConfirmAddRoleTask(ProposalConfirm):
             )
 
     def apply_update(
-        self, message, object_id, target_id, outputs, output_state, signer
+        self, message, object_id, related_id, outputs, output_state, signer
     ):
         """Create admin address"""
         addresser.role.task.create_relationship(
             object_id=object_id,
-            target_id=target_id,
+            related_id=related_id,
             outputs=outputs,
             output_state=output_state,
         )

--- a/rbac/common/role/create_role.py
+++ b/rbac/common/role/create_role.py
@@ -129,20 +129,20 @@ class CreateRole(BaseMessage):
             raise ValueError("The users {} were not found".format(users_not_found))
 
     def apply_update(
-        self, message, object_id, target_id, outputs, output_state, signer
+        self, message, object_id, related_id, outputs, output_state, signer
     ):
         """Create admin and owner addresses"""
         for admin in message.admins:
             addresser.role.admin.create_relationship(
                 object_id=object_id,
-                target_id=admin,
+                related_id=admin,
                 outputs=outputs,
                 output_state=output_state,
             )
         for admin in message.owners:
             addresser.role.owner.create_relationship(
                 object_id=object_id,
-                target_id=admin,
+                related_id=admin,
                 outputs=outputs,
                 output_state=output_state,
             )

--- a/rbac/common/role/propose_admin.py
+++ b/rbac/common/role/propose_admin.py
@@ -60,7 +60,7 @@ class ProposeAddRoleAdmin(ProposalPropose):
         user_address = addresser.user.address(message.user_id)
         role_address = addresser.role.address(message.role_id)
         proposal_address = self.address(
-            object_id=message.role_id, target_id=message.user_id
+            object_id=message.role_id, related_id=message.user_id
         )
 
         inputs = [relationship_address, role_address, user_address, proposal_address]
@@ -83,7 +83,7 @@ class ProposeAddRoleAdmin(ProposalPropose):
             inputs=inputs,
             input_state=input_state,
             object_id=message.role_id,
-            target_id=message.user_id,
+            related_id=message.user_id,
         ):
             raise ValueError(
                 "User {} is already an admin of role {}".format(

--- a/rbac/common/role/propose_member.py
+++ b/rbac/common/role/propose_member.py
@@ -60,7 +60,7 @@ class ProposeAddRoleMember(ProposalPropose):
         user_address = addresser.user.address(message.user_id)
         role_address = addresser.role.address(message.role_id)
         proposal_address = self.address(
-            object_id=message.role_id, target_id=message.user_id
+            object_id=message.role_id, related_id=message.user_id
         )
 
         inputs = [relationship_address, role_address, user_address, proposal_address]
@@ -83,7 +83,7 @@ class ProposeAddRoleMember(ProposalPropose):
             inputs=inputs,
             input_state=input_state,
             object_id=message.role_id,
-            target_id=message.user_id,
+            related_id=message.user_id,
         ):
             raise ValueError(
                 "User {} is already an admin of role {}".format(

--- a/rbac/common/role/propose_owner.py
+++ b/rbac/common/role/propose_owner.py
@@ -60,7 +60,7 @@ class ProposeAddRoleOwner(ProposalPropose):
         user_address = addresser.user.address(message.user_id)
         role_address = addresser.role.address(message.role_id)
         proposal_address = self.address(
-            object_id=message.role_id, target_id=message.user_id
+            object_id=message.role_id, related_id=message.user_id
         )
 
         inputs = [relationship_address, role_address, user_address, proposal_address]
@@ -83,7 +83,7 @@ class ProposeAddRoleOwner(ProposalPropose):
             inputs=inputs,
             input_state=input_state,
             object_id=message.role_id,
-            target_id=message.user_id,
+            related_id=message.user_id,
         ):
             raise ValueError(
                 "User {} is already an owner of role {}".format(

--- a/rbac/common/role/propose_task.py
+++ b/rbac/common/role/propose_task.py
@@ -60,7 +60,7 @@ class ProposeAddRoleTask(ProposalPropose):
         task_address = addresser.task.address(message.task_id)
         role_address = addresser.role.address(message.role_id)
         proposal_address = self.address(
-            object_id=message.role_id, target_id=message.task_id
+            object_id=message.role_id, related_id=message.task_id
         )
         signer_user_address = addresser.user.address(signer_keypair.public_key)
         signer_owner_address = addresser.role.owner.address(
@@ -95,7 +95,7 @@ class ProposeAddRoleTask(ProposalPropose):
             inputs=inputs,
             input_state=input_state,
             object_id=message.role_id,
-            target_id=message.task_id,
+            related_id=message.task_id,
         ):
             raise ValueError(
                 "Task {} is already a task of role {}".format(
@@ -106,7 +106,7 @@ class ProposeAddRoleTask(ProposalPropose):
             inputs=inputs,
             input_state=input_state,
             object_id=message.role_id,
-            target_id=signer,
+            related_id=signer,
         ):
             raise ValueError(
                 "Signer {} must be an owner of the role {}".format(

--- a/rbac/common/role/reject_admin.py
+++ b/rbac/common/role/reject_admin.py
@@ -68,7 +68,7 @@ class RejectAddRoleAdmin(ProposalReject):
         signer_user_address = addresser.user.address(signer_keypair.public_key)
 
         proposal_address = self.address(
-            object_id=message.role_id, target_id=message.user_id
+            object_id=message.role_id, related_id=message.user_id
         )
 
         inputs = [proposal_address, signer_admin_address, signer_user_address]
@@ -91,7 +91,7 @@ class RejectAddRoleAdmin(ProposalReject):
             inputs=inputs,
             input_state=input_state,
             object_id=message.role_id,
-            target_id=signer,
+            related_id=signer,
         ):
             raise ValueError(
                 "Signer {} must be an admin of the role {}".format(

--- a/rbac/common/role/reject_member.py
+++ b/rbac/common/role/reject_member.py
@@ -72,7 +72,7 @@ class RejectAddRoleMember(ProposalReject):
         signer_user_address = addresser.user.address(signer_keypair.public_key)
 
         proposal_address = self.address(
-            object_id=message.role_id, target_id=message.user_id
+            object_id=message.role_id, related_id=message.user_id
         )
 
         inputs = [
@@ -100,7 +100,7 @@ class RejectAddRoleMember(ProposalReject):
             inputs=inputs,
             input_state=input_state,
             object_id=message.role_id,
-            target_id=signer,
+            related_id=signer,
         ):
             raise ValueError(
                 "Signer {} must be an owner of the role {}".format(

--- a/rbac/common/role/reject_owner.py
+++ b/rbac/common/role/reject_owner.py
@@ -72,7 +72,7 @@ class RejectAddRoleOwner(ProposalReject):
         signer_user_address = addresser.user.address(signer_keypair.public_key)
 
         proposal_address = self.address(
-            object_id=message.role_id, target_id=message.user_id
+            object_id=message.role_id, related_id=message.user_id
         )
 
         inputs = [
@@ -101,7 +101,7 @@ class RejectAddRoleOwner(ProposalReject):
             inputs=inputs,
             input_state=input_state,
             object_id=message.role_id,
-            target_id=signer,
+            related_id=signer,
         ):
             raise ValueError(
                 "Signer {} must be an admin of the role {}".format(

--- a/rbac/common/role/reject_task.py
+++ b/rbac/common/role/reject_task.py
@@ -68,7 +68,7 @@ class RejectAddRoleTask(ProposalReject):
         signer_user_address = addresser.user.address(signer_keypair.public_key)
 
         proposal_address = self.address(
-            object_id=message.role_id, target_id=message.task_id
+            object_id=message.role_id, related_id=message.task_id
         )
 
         inputs = [proposal_address, signer_address, signer_user_address]
@@ -91,7 +91,7 @@ class RejectAddRoleTask(ProposalReject):
             inputs=inputs,
             input_state=input_state,
             object_id=message.task_id,
-            target_id=signer,
+            related_id=signer,
         ):
             raise ValueError(
                 "Signer {} must be an owner of the task {}".format(

--- a/rbac/common/sysadmin/sysadmin_address.py
+++ b/rbac/common/sysadmin/sysadmin_address.py
@@ -131,10 +131,10 @@ class SysAdminAddress(AddressBase):
         """The related type from AddressSpace implemented by this class"""
         return addresser.RelationshipType.ATTRIBUTES
 
-    def address(self, object_id=None, target_id=None):
+    def address(self, object_id=None, related_id=None):
         """Makes a blockchain address of this address type
         (sysadmin has no object_id, there is only one sysadmin role)"""
-        return self._address(object_id=object_id, target_id=target_id)
+        return self._address(object_id=object_id, related_id=related_id)
 
 
 SYSADMIN_ADDRESS = SysAdminAddress()

--- a/rbac/common/task/confirm_admin.py
+++ b/rbac/common/task/confirm_admin.py
@@ -68,7 +68,7 @@ class ConfirmAddTaskAdmin(ProposalConfirm):
         )
 
         proposal_address = self.address(
-            object_id=message.task_id, target_id=message.user_id
+            object_id=message.task_id, related_id=message.user_id
         )
 
         inputs = [
@@ -97,7 +97,7 @@ class ConfirmAddTaskAdmin(ProposalConfirm):
             inputs=inputs,
             input_state=input_state,
             object_id=message.task_id,
-            target_id=signer,
+            related_id=signer,
         ):
             raise ValueError(
                 "Signer {} must be an admin of the task {}".format(
@@ -106,12 +106,12 @@ class ConfirmAddTaskAdmin(ProposalConfirm):
             )
 
     def apply_update(
-        self, message, object_id, target_id, outputs, output_state, signer
+        self, message, object_id, related_id, outputs, output_state, signer
     ):
         """Create admin address"""
         addresser.task.admin.create_relationship(
             object_id=object_id,
-            target_id=target_id,
+            related_id=related_id,
             outputs=outputs,
             output_state=output_state,
         )

--- a/rbac/common/task/confirm_owner.py
+++ b/rbac/common/task/confirm_owner.py
@@ -72,7 +72,7 @@ class ConfirmAddTaskOwner(ProposalConfirm):
         )
 
         proposal_address = self.address(
-            object_id=message.task_id, target_id=message.user_id
+            object_id=message.task_id, related_id=message.user_id
         )
 
         inputs = [
@@ -102,12 +102,12 @@ class ConfirmAddTaskOwner(ProposalConfirm):
             inputs=inputs,
             input_state=input_state,
             object_id=message.task_id,
-            target_id=signer,
+            related_id=signer,
         ) and not addresser.task.admin.exists_in_state_inputs(
             inputs=inputs,
             input_state=input_state,
             object_id=message.task_id,
-            target_id=signer,
+            related_id=signer,
         ):
             raise ValueError(
                 "Signer {} must be an owner or admin of the task {}".format(
@@ -116,12 +116,12 @@ class ConfirmAddTaskOwner(ProposalConfirm):
             )
 
     def apply_update(
-        self, message, object_id, target_id, outputs, output_state, signer
+        self, message, object_id, related_id, outputs, output_state, signer
     ):
         """Create owner address"""
         addresser.task.owner.create_relationship(
             object_id=object_id,
-            target_id=target_id,
+            related_id=related_id,
             outputs=outputs,
             output_state=output_state,
         )

--- a/rbac/common/task/create_task.py
+++ b/rbac/common/task/create_task.py
@@ -125,20 +125,20 @@ class CreateTask(BaseMessage):
             raise ValueError("The users {} were not found".format(users_not_found))
 
     def apply_update(
-        self, message, object_id, target_id, outputs, output_state, signer
+        self, message, object_id, related_id, outputs, output_state, signer
     ):
         """Create admin and owner addresses"""
         for admin in message.admins:
             addresser.task.admin.create_relationship(
                 object_id=object_id,
-                target_id=admin,
+                related_id=admin,
                 outputs=outputs,
                 output_state=output_state,
             )
         for admin in message.owners:
             addresser.task.owner.create_relationship(
                 object_id=object_id,
-                target_id=admin,
+                related_id=admin,
                 outputs=outputs,
                 output_state=output_state,
             )

--- a/rbac/common/task/propose_admin.py
+++ b/rbac/common/task/propose_admin.py
@@ -60,7 +60,7 @@ class ProposeAddTaskAdmin(ProposalPropose):
         user_address = addresser.user.address(message.user_id)
         task_address = addresser.task.address(message.task_id)
         proposal_address = self.address(
-            object_id=message.task_id, target_id=message.user_id
+            object_id=message.task_id, related_id=message.user_id
         )
 
         inputs = [relationship_address, task_address, user_address, proposal_address]
@@ -83,7 +83,7 @@ class ProposeAddTaskAdmin(ProposalPropose):
             inputs=inputs,
             input_state=input_state,
             object_id=message.task_id,
-            target_id=message.user_id,
+            related_id=message.user_id,
         ):
             raise ValueError(
                 "User {} is already an admin of task {}".format(

--- a/rbac/common/task/propose_owner.py
+++ b/rbac/common/task/propose_owner.py
@@ -60,7 +60,7 @@ class ProposeAddTaskOwner(ProposalPropose):
         user_address = addresser.user.address(message.user_id)
         task_address = addresser.task.address(message.task_id)
         proposal_address = self.address(
-            object_id=message.task_id, target_id=message.user_id
+            object_id=message.task_id, related_id=message.user_id
         )
 
         inputs = [relationship_address, task_address, user_address, proposal_address]
@@ -83,7 +83,7 @@ class ProposeAddTaskOwner(ProposalPropose):
             inputs=inputs,
             input_state=input_state,
             object_id=message.task_id,
-            target_id=message.user_id,
+            related_id=message.user_id,
         ):
             raise ValueError(
                 "User {} is already an owner of task {}".format(

--- a/rbac/common/task/reject_admin.py
+++ b/rbac/common/task/reject_admin.py
@@ -63,7 +63,7 @@ class RejectAddTaskAdmin(ProposalReject):
         signer_user_address = addresser.user.address(signer_keypair.public_key)
 
         proposal_address = self.address(
-            object_id=message.task_id, target_id=message.user_id
+            object_id=message.task_id, related_id=message.user_id
         )
 
         inputs = [proposal_address, signer_admin_address, signer_user_address]
@@ -86,7 +86,7 @@ class RejectAddTaskAdmin(ProposalReject):
             inputs=inputs,
             input_state=input_state,
             object_id=message.task_id,
-            target_id=signer,
+            related_id=signer,
         ):
             raise ValueError(
                 "Signer {} must be an admin of the task {}".format(

--- a/rbac/common/task/reject_owner.py
+++ b/rbac/common/task/reject_owner.py
@@ -67,7 +67,7 @@ class RejectAddTaskOwner(ProposalReject):
         signer_user_address = addresser.user.address(signer_keypair.public_key)
 
         proposal_address = self.address(
-            object_id=message.task_id, target_id=message.user_id
+            object_id=message.task_id, related_id=message.user_id
         )
 
         inputs = [
@@ -95,12 +95,12 @@ class RejectAddTaskOwner(ProposalReject):
             inputs=inputs,
             input_state=input_state,
             object_id=message.task_id,
-            target_id=signer,
+            related_id=signer,
         ) and not addresser.task.admin.exists_in_state_inputs(
             inputs=inputs,
             input_state=input_state,
             object_id=message.task_id,
-            target_id=signer,
+            related_id=signer,
         ):
             raise ValueError(
                 "Signer {} must be an owner or admin of the task {}".format(

--- a/rbac/common/user/confirm_manager.py
+++ b/rbac/common/user/confirm_manager.py
@@ -55,7 +55,7 @@ class ConfirmUpdateUserManager(ProposalConfirm):
             raise TypeError("Expected message to be {}".format(self.message_proto))
 
         proposal_address = addresser.proposal.address(
-            object_id=message.user_id, target_id=message.manager_id
+            object_id=message.user_id, related_id=message.manager_id
         )
         user_address = addresser.user.address(message.user_id)
         signer_user_address = addresser.user.address(signer_keypair.public_key)
@@ -97,10 +97,10 @@ class ConfirmUpdateUserManager(ProposalConfirm):
             )
 
     def store_message(
-        self, object_id, target_id, store, message, outputs, output_state, signer
+        self, object_id, related_id, store, message, outputs, output_state, signer
     ):
         super().store_message(
-            object_id, target_id, store, message, outputs, output_state, signer
+            object_id, related_id, store, message, outputs, output_state, signer
         )
         addresser.user.set_output_state_attribute(
             name="manager_id",
@@ -108,5 +108,5 @@ class ConfirmUpdateUserManager(ProposalConfirm):
             outputs=outputs,
             output_state=output_state,
             object_id=message.user_id,
-            target_id=None,
+            related_id=None,
         )

--- a/rbac/common/user/propose_manager.py
+++ b/rbac/common/user/propose_manager.py
@@ -50,8 +50,8 @@ class ProposeUpdateUserManager(ProposalPropose):
         return addresser.RelationshipType.MANAGER
 
     @property
-    def _target_id(self):
-        """The attribute name for target_id"""
+    def _related_id(self):
+        """The attribute name for related_id"""
         return "new_manager_id"
 
     def make_addresses(self, message, signer_keypair):
@@ -62,7 +62,7 @@ class ProposeUpdateUserManager(ProposalPropose):
         user_address = addresser.user.address(message.user_id)
         manager_address = addresser.user.address(message.new_manager_id)
         proposal_address = addresser.proposal.address(
-            object_id=message.user_id, target_id=message.new_manager_id
+            object_id=message.user_id, related_id=message.new_manager_id
         )
         signer_user_address = addresser.user.address(signer_keypair.public_key)
 

--- a/rbac/common/user/reject_manager.py
+++ b/rbac/common/user/reject_manager.py
@@ -60,7 +60,7 @@ class RejectUpdateUserManager(ProposalReject):
             raise TypeError("Expected message to be {}".format(self.message_proto))
 
         proposal_address = addresser.proposal.address(
-            object_id=message.user_id, target_id=message.manager_id
+            object_id=message.user_id, related_id=message.manager_id
         )
         signer_user_address = addresser.user.address(signer_keypair.public_key)
 

--- a/rbac/ledger_sync/deltas/updating.py
+++ b/rbac/ledger_sync/deltas/updating.py
@@ -93,7 +93,7 @@ def _update_state(database, block_num, address, resource):
             "object_id": bytes_from_hex(address_parts.object_id),
             "related_type": address_parts.related_type.value,
             "relationship_type": address_parts.relationship_type.value,
-            "related_id": bytes_from_hex(address_parts.target_id),
+            "related_id": bytes_from_hex(address_parts.related_id),
             "data": resource,
         }
         table_query = database.get_table("state")

--- a/rbac/processor/proposal_validator.py
+++ b/rbac/processor/proposal_validator.py
@@ -36,7 +36,7 @@ def has_no_open_proposal(
     for proposal in prop_container.proposals:
         if (
             proposal.object_id == object_id
-            and proposal.target_id == related_id
+            and proposal.related_id == related_id
             and proposal.status == proposal_state_pb2.Proposal.OPEN
             and proposal.proposal_type == proposal_type
         ):

--- a/rbac/processor/role/role_admins.py
+++ b/rbac/processor/role/role_admins.py
@@ -38,7 +38,7 @@ def apply_propose(header, payload, state):
     )
 
     proposal_address = addresser.proposal.address(
-        object_id=role_admins_payload.role_id, target_id=role_admins_payload.user_id
+        object_id=role_admins_payload.role_id, related_id=role_admins_payload.user_id
     )
 
     state_entries = role_validator.validate_role_rel_proposal(
@@ -78,7 +78,7 @@ def apply_propose_remove(header, payload, state):
     )
 
     proposal_address = addresser.proposal.address(
-        object_id=role_admins_payload.role_id, target_id=role_admins_payload.user_id
+        object_id=role_admins_payload.role_id, related_id=role_admins_payload.user_id
     )
 
     state_entries = role_validator.validate_role_rel_proposal(

--- a/rbac/processor/role/role_members.py
+++ b/rbac/processor/role/role_members.py
@@ -35,7 +35,7 @@ def apply_propose(header, payload, state):
     )
 
     proposal_address = addresser.proposal.address(
-        object_id=proposal_payload.role_id, target_id=proposal_payload.user_id
+        object_id=proposal_payload.role_id, related_id=proposal_payload.user_id
     )
 
     state_entries = role_validator.validate_role_rel_proposal(
@@ -75,7 +75,7 @@ def apply_propose_remove(header, payload, state):
     )
 
     proposal_address = addresser.proposal.address(
-        object_id=proposal_payload.role_id, target_id=proposal_payload.user_id
+        object_id=proposal_payload.role_id, related_id=proposal_payload.user_id
     )
 
     state_entries = role_validator.validate_role_rel_proposal(

--- a/rbac/processor/role/role_operation.py
+++ b/rbac/processor/role/role_operation.py
@@ -25,7 +25,7 @@ from rbac.processor import state_accessor
 
 def hierarchical_decide(header, confirm, state, txn_signer_rel_address, isApproval):
     proposal_address = addresser.proposal.address(
-        object_id=confirm.role_id, target_id=confirm.user_id
+        object_id=confirm.role_id, related_id=confirm.user_id
     )
 
     state_entries = state_accessor.get_state(

--- a/rbac/processor/role/role_owners.py
+++ b/rbac/processor/role/role_owners.py
@@ -35,7 +35,7 @@ def apply_propose(header, payload, state):
     )
 
     proposal_address = addresser.proposal.address(
-        object_id=proposal_payload.role_id, target_id=proposal_payload.user_id
+        object_id=proposal_payload.role_id, related_id=proposal_payload.user_id
     )
 
     state_entries = role_validator.validate_role_rel_proposal(
@@ -75,7 +75,7 @@ def apply_propose_remove(header, payload, state):
     )
 
     proposal_address = addresser.proposal.address(
-        object_id=proposal_payload.role_id, target_id=proposal_payload.user_id
+        object_id=proposal_payload.role_id, related_id=proposal_payload.user_id
     )
 
     state_entries = role_validator.validate_role_rel_proposal(

--- a/rbac/processor/role/role_validator.py
+++ b/rbac/processor/role/role_validator.py
@@ -40,7 +40,7 @@ def validate_role_rel_proposal(header, propose, rel_address, state, is_remove=Fa
     user_address = addresser.user.address(propose.user_id)
     role_address = addresser.role.address(propose.role_id)
     proposal_address = addresser.proposal.address(
-        object_id=propose.role_id, target_id=propose.user_id
+        object_id=propose.role_id, related_id=propose.user_id
     )
 
     state_entries = state_accessor.get_state(
@@ -152,7 +152,7 @@ def validate_create_role_state(create_role, state):
 
 def validate_role_task(header, confirm, txn_signer_rel_address, state):
     proposal_address = addresser.proposal.address(
-        object_id=confirm.role_id, target_id=confirm.task_id
+        object_id=confirm.role_id, related_id=confirm.task_id
     )
 
     state_entries = state_accessor.get_state(
@@ -212,7 +212,7 @@ def get_state_entries(header, confirm, txn_signer_rel_address, state):
     """
 
     proposal_address = addresser.proposal.address(
-        object_id=confirm.role_id, target_id=confirm.user_id
+        object_id=confirm.role_id, related_id=confirm.user_id
     )
 
     state_entries = state_accessor.get_state(

--- a/rbac/processor/state_change.py
+++ b/rbac/processor/state_change.py
@@ -91,7 +91,7 @@ def propose_manager_change(proposal_state_entries, header, user_proposal, state)
     proposal.proposal_id = user_proposal.proposal_id
     proposal.proposal_type = proposal_state_pb2.Proposal.UPDATE_USER_MANAGER
     proposal.object_id = user_proposal.user_id
-    proposal.target_id = user_proposal.new_manager_id
+    proposal.related_id = user_proposal.new_manager_id
     proposal.opener = header.signer_public_key
     proposal.status = proposal_state_pb2.Proposal.OPEN
     proposal.open_reason = user_proposal.reason
@@ -143,7 +143,7 @@ def propose_task_action(
 
     proposal.proposal_id = payload.proposal_id
     proposal.object_id = payload.task_id
-    proposal.target_id = getattr(payload, related_type)
+    proposal.related_id = getattr(payload, related_type)
     proposal.proposal_type = proposal_type
     proposal.status = proposal_state_pb2.Proposal.OPEN
     proposal.opener = header.signer_public_key
@@ -170,7 +170,7 @@ def confirm_task_action(
 
     """
     proposal_address = addresser.proposal.address(
-        object_id=confirm.task_id, target_id=confirm.user_id
+        object_id=confirm.task_id, related_id=confirm.user_id
     )
 
     proposal_entry = state_accessor.get_state_entry(state_entries, proposal_address)
@@ -213,7 +213,7 @@ def confirm_task_action(
 
 def reject_task_action(state_entries, header, reject, state):
     proposal_address = addresser.proposal.address(
-        object_id=reject.task_id, target_id=reject.user_id
+        object_id=reject.task_id, related_id=reject.user_id
     )
 
     proposal_entry = state_accessor.get_state_entry(state_entries, proposal_address)
@@ -250,7 +250,7 @@ def propose_role_action(
 
     proposal.proposal_id = payload.proposal_id
     proposal.object_id = payload.role_id
-    proposal.target_id = getattr(payload, related_type)
+    proposal.related_id = getattr(payload, related_type)
     proposal.proposal_type = proposal_type
     proposal.status = proposal_state_pb2.Proposal.OPEN
     proposal.opener = header.signer_public_key
@@ -264,7 +264,7 @@ def confirm_role_action(
     state_entries, header, confirm, role_rel_address, state, rel_type="user_id"
 ):
     proposal_address = addresser.proposal.address(
-        object_id=confirm.role_id, target_id=getattr(confirm, rel_type)
+        object_id=confirm.role_id, related_id=getattr(confirm, rel_type)
     )
 
     proposal_entry = state_accessor.get_state_entry(state_entries, proposal_address)
@@ -301,7 +301,7 @@ def confirm_role_action(
 
 def reject_role_action(state_entries, header, reject, state, rel_type="user_id"):
     proposal_address = addresser.proposal.address(
-        object_id=reject.role_id, target_id=getattr(reject, rel_type)
+        object_id=reject.role_id, related_id=getattr(reject, rel_type)
     )
 
     proposal_entry = state_accessor.get_state_entry(state_entries, proposal_address)
@@ -357,7 +357,7 @@ def record_decision(state, header, confirm, isApproval):
     on_behalf_id = confirm.on_behalf_id
 
     proposal_address = addresser.proposal.address(
-        object_id=confirm.role_id, target_id=confirm.user_id
+        object_id=confirm.role_id, related_id=confirm.user_id
     )
 
     state_entries = state_accessor.get_state(state, [proposal_address])

--- a/rbac/processor/task/task_owners.py
+++ b/rbac/processor/task/task_owners.py
@@ -30,7 +30,7 @@ def apply_propose(header, payload, state):
     task_owners_address = addresser.task.owner.address(propose.task_id, propose.user_id)
 
     proposal_address = addresser.proposal.address(
-        object_id=propose.task_id, target_id=propose.user_id
+        object_id=propose.task_id, related_id=propose.user_id
     )
 
     state_entries = task_validator.validate_task_rel_proposal(
@@ -66,7 +66,7 @@ def apply_propose_remove(header, payload, state):
     task_owners_address = addresser.task.owner.address(propose.task_id, propose.user_id)
 
     proposal_address = addresser.proposal.address(
-        object_id=propose.task_id, target_id=propose.user_id
+        object_id=propose.task_id, related_id=propose.user_id
     )
 
     state_entries = task_validator.validate_task_rel_del_proposal(

--- a/rbac/processor/task/task_validator.py
+++ b/rbac/processor/task/task_validator.py
@@ -52,7 +52,7 @@ def validate_task_rel_proposal(header, propose, rel_address, state):
     user_id = propose.user_id
     user_address = addresser.user.address(user_id)
     task_address = addresser.task.address(task_id)
-    proposal_address = addresser.proposal.address(object_id=task_id, target_id=user_id)
+    proposal_address = addresser.proposal.address(object_id=task_id, related_id=user_id)
 
     state_entries = state_accessor.get_state(
         state, [user_address, task_address, proposal_address, rel_address]
@@ -116,7 +116,7 @@ def validate_task_rel_del_proposal(header, propose, rel_address, state):
     task_address = addresser.task.address(propose.task_id)
 
     proposal_address = addresser.proposal.address(
-        object_id=propose.task_id, target_id=propose.user_id
+        object_id=propose.task_id, related_id=propose.user_id
     )
 
     state_entries = state_accessor.get_state(
@@ -193,7 +193,7 @@ def validate_task_admin_or_owner(
     """
 
     proposal_address = addresser.proposal.address(
-        object_id=confirm.task_id, target_id=confirm.user_id
+        object_id=confirm.task_id, related_id=confirm.user_id
     )
 
     if not is_remove:

--- a/rbac/processor/user/user_manager_proposal.py
+++ b/rbac/processor/user/user_manager_proposal.py
@@ -86,7 +86,7 @@ def _validate_state_and_return_user(header, user_proposal, state):
 
 def _validate_unique_proposal(user_proposal, state):
     proposal_address = addresser.proposal.address(
-        object_id=user_proposal.user_id, target_id=user_proposal.new_manager_id
+        object_id=user_proposal.user_id, related_id=user_proposal.new_manager_id
     )
     state_return = state_accessor.get_state(state, [proposal_address])
     if not proposal_validator.has_no_open_proposal(
@@ -120,7 +120,7 @@ def apply_user_confirm(header, payload, state):
     confirm_payload.ParseFromString(payload.content)
 
     proposal_address = addresser.proposal.address(
-        object_id=confirm_payload.user_id, target_id=confirm_payload.manager_id
+        object_id=confirm_payload.user_id, related_id=confirm_payload.manager_id
     )
 
     proposal_entries = state_accessor.get_state(state, [proposal_address])
@@ -144,10 +144,12 @@ def apply_user_confirm(header, payload, state):
         container=proposal_container, proposal_id=confirm_payload.proposal_id
     )
 
-    if not proposal.target_id == header.signer_public_key:
+    if not proposal.related_id == header.signer_public_key:
         raise InvalidTransaction(
             "Confirm update manager txn signed by {} while "
-            "proposal expecting {}".format(header.signer_public_key, proposal.target_id)
+            "proposal expecting {}".format(
+                header.signer_public_key, proposal.related_id
+            )
         )
 
     state_change.confirm_manager_change(
@@ -167,7 +169,7 @@ def apply_user_reject(header, payload, state):
     reject_payload.ParseFromString(payload.content)
 
     proposal_address = addresser.proposal.address(
-        object_id=reject_payload.user_id, target_id=reject_payload.manager_id
+        object_id=reject_payload.user_id, related_id=reject_payload.manager_id
     )
 
     state_entries = state_accessor.get_state(state, [proposal_address])

--- a/rbac/server/db/proposals_query.py
+++ b/rbac/server/db/proposals_query.py
@@ -36,7 +36,7 @@ async def fetch_all_proposal_resources(conn, head_block_num, start, limit):
                     "id": proposal["proposal_id"],
                     "type": proposal["proposal_type"],
                     "object": proposal["object_id"],
-                    "target": proposal["target_id"],
+                    "target": proposal["related_id"],
                 }
             )
         )
@@ -51,7 +51,7 @@ async def fetch_all_proposal_resources(conn, head_block_num, start, limit):
             "proposal_id",
             "proposal_type",
             "object_id",
-            "target_id",
+            "related_id",
         )
         .coerce_to("array")
         .run(conn)
@@ -72,7 +72,7 @@ async def fetch_proposal_resource(conn, proposal_id, head_block_num):
                     "id": proposal["proposal_id"],
                     "type": proposal["proposal_type"],
                     "object": proposal["object_id"],
-                    "target": proposal["target_id"],
+                    "target": proposal["related_id"],
                 }
             )
         )
@@ -87,7 +87,7 @@ async def fetch_proposal_resource(conn, proposal_id, head_block_num):
             "proposal_id",
             "proposal_type",
             "object_id",
-            "target_id",
+            "related_id",
         )
         .coerce_to("array")
         .run(conn)
@@ -117,7 +117,7 @@ def fetch_approver_ids(table, object_id, head_block_num):
 def fetch_proposal_ids_by_target(target, head_block_num):
     return (
         r.table("proposals")
-        .get_all(target, index="target_id")
+        .get_all(target, index="related_id")
         .filter(
             lambda doc: (head_block_num >= doc["start_block_num"])
             & (head_block_num < doc["end_block_num"])

--- a/rbac/transaction_creation/manager_transaction_creation.py
+++ b/rbac/transaction_creation/manager_transaction_creation.py
@@ -52,11 +52,11 @@ def propose_manager(
     inputs = [
         addresser.user.address(user_id),
         addresser.user.address(new_manager_id),
-        addresser.proposal.address(object_id=user_id, target_id=new_manager_id),
+        addresser.proposal.address(object_id=user_id, related_id=new_manager_id),
         addresser.user.address(txn_key.public_key),
     ]
 
-    outputs = [addresser.proposal.address(object_id=user_id, target_id=new_manager_id)]
+    outputs = [addresser.proposal.address(object_id=user_id, related_id=new_manager_id)]
 
     rbac_payload = rbac_payload_pb2.RBACPayload(
         content=propose_update_payload.SerializeToString(),
@@ -128,11 +128,11 @@ def reject_manager(txn_key, batch_key, proposal_id, reason, user_id, manager_id)
     )
 
     inputs = [
-        addresser.proposal.address(object_id=user_id, target_id=manager_id),
+        addresser.proposal.address(object_id=user_id, related_id=manager_id),
         addresser.user.address(txn_key.public_key),
     ]
 
-    outputs = [addresser.proposal.address(object_id=user_id, target_id=manager_id)]
+    outputs = [addresser.proposal.address(object_id=user_id, related_id=manager_id)]
 
     rbac_payload = rbac_payload_pb2.RBACPayload(
         content=reject_update_payload.SerializeToString(),

--- a/tests/rbac/common/addresser/legacy_test.py
+++ b/tests/rbac/common/addresser/legacy_test.py
@@ -112,19 +112,19 @@ class TestAddressLegacyCompatibility(TestAssertions):
         )
         self.assertEqual(
             legacy.make_role_owners_address(role_id=unique_id, user_id=user_id),
-            addresser.role.owner.address(object_id=unique_id, target_id=user_id),
+            addresser.role.owner.address(object_id=unique_id, related_id=user_id),
         )
         self.assertEqual(
             legacy.make_role_admins_address(role_id=unique_id, user_id=user_id),
-            addresser.role.admin.address(object_id=unique_id, target_id=user_id),
+            addresser.role.admin.address(object_id=unique_id, related_id=user_id),
         )
         self.assertEqual(
             legacy.make_role_members_address(role_id=unique_id, user_id=user_id),
-            addresser.role.member.address(object_id=unique_id, target_id=user_id),
+            addresser.role.member.address(object_id=unique_id, related_id=user_id),
         )
         self.assertEqual(
             legacy.make_role_tasks_address(role_id=unique_id, task_id=unique_id2),
-            addresser.role.task.address(object_id=unique_id, target_id=unique_id2),
+            addresser.role.task.address(object_id=unique_id, related_id=unique_id2),
         )
 
         self.assertEqual(
@@ -133,11 +133,11 @@ class TestAddressLegacyCompatibility(TestAssertions):
         )
         self.assertEqual(
             legacy.make_task_owners_address(task_id=unique_id, user_id=user_id),
-            addresser.task.owner.address(object_id=unique_id, target_id=user_id),
+            addresser.task.owner.address(object_id=unique_id, related_id=user_id),
         )
         self.assertEqual(
             legacy.make_task_admins_address(task_id=unique_id, user_id=user_id),
-            addresser.task.admin.address(object_id=unique_id, target_id=user_id),
+            addresser.task.admin.address(object_id=unique_id, related_id=user_id),
         )
 
         self.assertEqual(
@@ -159,11 +159,11 @@ class TestAddressLegacyCompatibility(TestAssertions):
     def test_proposal_address_static(self):
         """Test addreser makes expected address"""
         object_id = "cb048d507eec42a5845e20eed982d5d2"
-        target_id = "f1e916b663164211a9ac34516324681a"
+        related_id = "f1e916b663164211a9ac34516324681a"
         expected_address = "9f4448e3b874e90b2bcf58e65e0727\
 91ea499543ee52fc9d0449fc1e41f77d4d4f926e"
         proposal_address = addresser.proposal.address(
-            object_id=object_id, target_id=target_id
+            object_id=object_id, related_id=related_id
         )
         self.assertIsAddress(proposal_address)
         self.assertEqual(proposal_address, expected_address)
@@ -177,7 +177,9 @@ class TestAddressLegacyCompatibility(TestAssertions):
         user_id = "966ab67317234df489adb4bc1f517b88"
         expected_address = "9f444809326a1713a905b26359fc8d\
 a2817c1a5f67de6f464701f0c10042da345d28f7"
-        rel_address = addresser.role.admin.address(object_id=role_id, target_id=user_id)
+        rel_address = addresser.role.admin.address(
+            object_id=role_id, related_id=user_id
+        )
         self.assertIsAddress(rel_address)
         self.assertEqual(rel_address, expected_address)
         self.assertEqual(
@@ -191,7 +193,7 @@ a2817c1a5f67de6f464701f0c10042da345d28f7"
         expected_address = "9f444809326a1713a905b26359fc8d\
 a2817c1a5f67de6f464701f0c10042da345d2833"
         rel_address = addresser.role.member.address(
-            object_id=role_id, target_id=user_id
+            object_id=role_id, related_id=user_id
         )
         self.assertIsAddress(rel_address)
         self.assertEqual(rel_address, expected_address)
@@ -205,7 +207,9 @@ a2817c1a5f67de6f464701f0c10042da345d2833"
         user_id = "966ab67317234df489adb4bc1f517b88"
         expected_address = "9f444809326a1713a905b26359fc8d\
 a2817c1a5f67de6f464701f0c10042da345d2893"
-        rel_address = addresser.role.owner.address(object_id=role_id, target_id=user_id)
+        rel_address = addresser.role.owner.address(
+            object_id=role_id, related_id=user_id
+        )
         self.assertIsAddress(rel_address)
         self.assertEqual(rel_address, expected_address)
         self.assertEqual(
@@ -218,7 +222,7 @@ a2817c1a5f67de6f464701f0c10042da345d2893"
         task_id = "966ab67317234df489adb4bc1f517b88"
         expected_address = "9f444809326a1713a905b26359fc8d\
 a2817c1a5f67de6f464701f0c10042da345d28c5"
-        rel_address = addresser.role.task.address(object_id=role_id, target_id=task_id)
+        rel_address = addresser.role.task.address(object_id=role_id, related_id=task_id)
         self.assertIsAddress(rel_address)
         self.assertEqual(rel_address, expected_address)
         self.assertEqual(
@@ -291,7 +295,9 @@ a2817c1a5f67de6f464701f0c10042da345d2800"
         user_id = "966ab67317234df489adb4bc1f517b88"
         expected_address = "9f44481e326a1713a905b26359fc8d\
 a2817c1a5f67de6f464701f0c10042da345d2848"
-        rel_address = addresser.task.admin.address(object_id=task_id, target_id=user_id)
+        rel_address = addresser.task.admin.address(
+            object_id=task_id, related_id=user_id
+        )
         self.assertIsAddress(rel_address)
         self.assertEqual(rel_address, expected_address)
         self.assertEqual(
@@ -304,7 +310,9 @@ a2817c1a5f67de6f464701f0c10042da345d2848"
         user_id = "966ab67317234df489adb4bc1f517b88"
         expected_address = "9f44481e326a1713a905b26359fc8d\
 a2817c1a5f67de6f464701f0c10042da345d2808"
-        rel_address = addresser.task.owner.address(object_id=task_id, target_id=user_id)
+        rel_address = addresser.task.owner.address(
+            object_id=task_id, related_id=user_id
+        )
         self.assertIsAddress(rel_address)
         self.assertEqual(rel_address, expected_address)
         self.assertEqual(

--- a/tests/rbac/common/addresser/proposal_test.py
+++ b/tests/rbac/common/addresser/proposal_test.py
@@ -30,9 +30,9 @@ class TestProposalAddresser(TestAssertions):
     def test_address(self):
         """Tests address makes an address that identifies as the correct AddressSpace"""
         object_id = addresser.proposal.unique_id()
-        target_id = addresser.proposal.unique_id()
+        related_id = addresser.proposal.unique_id()
         proposal_address = addresser.proposal.address(
-            object_id=object_id, target_id=target_id
+            object_id=object_id, related_id=related_id
         )
         self.assertIsAddress(proposal_address)
         self.assertEqual(
@@ -42,12 +42,12 @@ class TestProposalAddresser(TestAssertions):
     def test_address_deterministic(self):
         """Tests address generates the same output given the same input"""
         object_id = addresser.proposal.unique_id()
-        target_id = addresser.proposal.unique_id()
+        related_id = addresser.proposal.unique_id()
         proposal_address1 = addresser.proposal.address(
-            object_id=object_id, target_id=target_id
+            object_id=object_id, related_id=related_id
         )
         proposal_address2 = addresser.proposal.address(
-            object_id=object_id, target_id=target_id
+            object_id=object_id, related_id=related_id
         )
         self.assertIsAddress(proposal_address1)
         self.assertIsAddress(proposal_address2)
@@ -59,14 +59,14 @@ class TestProposalAddresser(TestAssertions):
     def test_address_random(self):
         """Tests address makes a unique address given different inputs"""
         object_id1 = addresser.proposal.unique_id()
-        target_id1 = addresser.proposal.unique_id()
+        related_id1 = addresser.proposal.unique_id()
         object_id2 = addresser.proposal.unique_id()
-        target_id2 = addresser.proposal.unique_id()
+        related_id2 = addresser.proposal.unique_id()
         proposal_address1 = addresser.proposal.address(
-            object_id=object_id1, target_id=target_id1
+            object_id=object_id1, related_id=related_id1
         )
         proposal_address2 = addresser.proposal.address(
-            object_id=object_id2, target_id=target_id2
+            object_id=object_id2, related_id=related_id2
         )
         self.assertIsAddress(proposal_address1)
         self.assertIsAddress(proposal_address2)
@@ -81,12 +81,12 @@ class TestProposalAddresser(TestAssertions):
     def test_address_static(self):
         """Tests address makes the expected output given a specific input"""
         object_id = "cb048d507eec42a5845e20eed982d5d2"
-        target_id = "f1e916b663164211a9ac34516324681a"
+        related_id = "f1e916b663164211a9ac34516324681a"
         expected_address = (
             "bac00100004444b874e90b2bcf58e65e0727911111ff3ee52fc9d0449fc1e41f77d400"
         )
         proposal_address = addresser.proposal.address(
-            object_id=object_id, target_id=target_id
+            object_id=object_id, related_id=related_id
         )
         self.assertIsAddress(proposal_address)
         self.assertEqual(proposal_address, expected_address)

--- a/tests/rbac/common/addresser/role_admin_test.py
+++ b/tests/rbac/common/addresser/role_admin_test.py
@@ -31,7 +31,9 @@ class TestRoleAdminAddresser(TestAssertions):
         """Tests address makes an address that identifies as the correct AddressSpace"""
         role_id = addresser.role.admin.unique_id()
         user_id = addresser.user.unique_id()
-        rel_address = addresser.role.admin.address(object_id=role_id, target_id=user_id)
+        rel_address = addresser.role.admin.address(
+            object_id=role_id, related_id=user_id
+        )
         self.assertIsAddress(rel_address)
         self.assertEqual(
             addresser.address_is(rel_address), addresser.AddressSpace.ROLES_ADMINS
@@ -42,10 +44,10 @@ class TestRoleAdminAddresser(TestAssertions):
         role_id = addresser.role.admin.unique_id()
         user_id = addresser.user.unique_id()
         rel_address1 = addresser.role.admin.address(
-            object_id=role_id, target_id=user_id
+            object_id=role_id, related_id=user_id
         )
         rel_address2 = addresser.role.admin.address(
-            object_id=role_id, target_id=user_id
+            object_id=role_id, related_id=user_id
         )
         self.assertIsAddress(rel_address1)
         self.assertIsAddress(rel_address2)
@@ -61,10 +63,10 @@ class TestRoleAdminAddresser(TestAssertions):
         role_id2 = addresser.role.admin.unique_id()
         user_id2 = addresser.user.unique_id()
         rel_address1 = addresser.role.admin.address(
-            object_id=role_id1, target_id=user_id1
+            object_id=role_id1, related_id=user_id1
         )
         rel_address2 = addresser.role.admin.address(
-            object_id=role_id2, target_id=user_id2
+            object_id=role_id2, related_id=user_id2
         )
         self.assertIsAddress(rel_address1)
         self.assertIsAddress(rel_address2)
@@ -83,7 +85,9 @@ class TestRoleAdminAddresser(TestAssertions):
         expected_address = (
             "bac00100005555326a1713a905b26359fc8da23333eee7570f3f6f7d2c1635f6deea00"
         )
-        rel_address = addresser.role.admin.address(object_id=role_id, target_id=user_id)
+        rel_address = addresser.role.admin.address(
+            object_id=role_id, related_id=user_id
+        )
         self.assertIsAddress(rel_address)
         self.assertEqual(rel_address, expected_address)
         self.assertEqual(

--- a/tests/rbac/common/addresser/role_member_test.py
+++ b/tests/rbac/common/addresser/role_member_test.py
@@ -33,7 +33,7 @@ class TestRoleMemberAddresser(TestAssertions):
         role_id = addresser.role.member.unique_id()
         user_id = addresser.user.unique_id()
         rel_address = addresser.role.member.address(
-            object_id=role_id, target_id=user_id
+            object_id=role_id, related_id=user_id
         )
         self.assertIsAddress(rel_address)
         self.assertEqual(
@@ -45,10 +45,10 @@ class TestRoleMemberAddresser(TestAssertions):
         role_id = addresser.role.member.unique_id()
         user_id = addresser.user.unique_id()
         rel_address1 = addresser.role.member.address(
-            object_id=role_id, target_id=user_id
+            object_id=role_id, related_id=user_id
         )
         rel_address2 = addresser.role.member.address(
-            object_id=role_id, target_id=user_id
+            object_id=role_id, related_id=user_id
         )
         self.assertIsAddress(rel_address1)
         self.assertIsAddress(rel_address2)
@@ -64,10 +64,10 @@ class TestRoleMemberAddresser(TestAssertions):
         role_id2 = addresser.role.member.unique_id()
         user_id2 = addresser.user.unique_id()
         rel_address1 = addresser.role.member.address(
-            object_id=role_id1, target_id=user_id1
+            object_id=role_id1, related_id=user_id1
         )
         rel_address2 = addresser.role.member.address(
-            object_id=role_id2, target_id=user_id2
+            object_id=role_id2, related_id=user_id2
         )
         self.assertIsAddress(rel_address1)
         self.assertIsAddress(rel_address2)
@@ -87,7 +87,7 @@ class TestRoleMemberAddresser(TestAssertions):
             "bac00100005555326a1713a905b26359fc8da23333bbe7570f3f6f7d2c1635f6deea00"
         )
         rel_address = addresser.role.member.address(
-            object_id=role_id, target_id=user_id
+            object_id=role_id, related_id=user_id
         )
         self.assertIsAddress(rel_address)
         self.assertEqual(rel_address, expected_address)

--- a/tests/rbac/common/addresser/role_owner_test.py
+++ b/tests/rbac/common/addresser/role_owner_test.py
@@ -32,7 +32,9 @@ class TestRoleOwnerAddresser(TestAssertions):
         """Tests address makes an address that identifies as the correct AddressSpace"""
         role_id = addresser.role.owner.unique_id()
         user_id = addresser.user.unique_id()
-        rel_address = addresser.role.owner.address(object_id=role_id, target_id=user_id)
+        rel_address = addresser.role.owner.address(
+            object_id=role_id, related_id=user_id
+        )
         self.assertIsAddress(rel_address)
         self.assertEqual(
             addresser.address_is(rel_address), addresser.AddressSpace.ROLES_OWNERS
@@ -43,10 +45,10 @@ class TestRoleOwnerAddresser(TestAssertions):
         role_id = addresser.role.owner.unique_id()
         user_id = addresser.user.unique_id()
         rel_address1 = addresser.role.owner.address(
-            object_id=role_id, target_id=user_id
+            object_id=role_id, related_id=user_id
         )
         rel_address2 = addresser.role.owner.address(
-            object_id=role_id, target_id=user_id
+            object_id=role_id, related_id=user_id
         )
         self.assertIsAddress(rel_address1)
         self.assertIsAddress(rel_address2)
@@ -62,10 +64,10 @@ class TestRoleOwnerAddresser(TestAssertions):
         role_id2 = addresser.role.owner.unique_id()
         user_id2 = addresser.user.unique_id()
         rel_address1 = addresser.role.owner.address(
-            object_id=role_id1, target_id=user_id1
+            object_id=role_id1, related_id=user_id1
         )
         rel_address2 = addresser.role.owner.address(
-            object_id=role_id2, target_id=user_id2
+            object_id=role_id2, related_id=user_id2
         )
         self.assertIsAddress(rel_address1)
         self.assertIsAddress(rel_address2)
@@ -84,7 +86,9 @@ class TestRoleOwnerAddresser(TestAssertions):
         expected_address = (
             "bac00100005555326a1713a905b26359fc8da23333cce7570f3f6f7d2c1635f6deea00"
         )
-        rel_address = addresser.role.owner.address(object_id=role_id, target_id=user_id)
+        rel_address = addresser.role.owner.address(
+            object_id=role_id, related_id=user_id
+        )
         self.assertIsAddress(rel_address)
         self.assertEqual(rel_address, expected_address)
         self.assertEqual(

--- a/tests/rbac/common/addresser/role_task_test.py
+++ b/tests/rbac/common/addresser/role_task_test.py
@@ -31,7 +31,7 @@ class TestRoleTaskAddresser(TestAssertions):
         """Tests address makes an address that identifies as the correct AddressSpace"""
         role_id = addresser.role.task.unique_id()
         task_id = addresser.task.unique_id()
-        rel_address = addresser.role.task.address(object_id=role_id, target_id=task_id)
+        rel_address = addresser.role.task.address(object_id=role_id, related_id=task_id)
         self.assertIsAddress(rel_address)
         self.assertEqual(
             addresser.address_is(rel_address), addresser.AddressSpace.ROLES_TASKS
@@ -41,8 +41,12 @@ class TestRoleTaskAddresser(TestAssertions):
         """Tests address makes an address that identifies as the correct AddressSpace"""
         role_id = addresser.role.task.unique_id()
         task_id = addresser.task.unique_id()
-        rel_address1 = addresser.role.task.address(object_id=role_id, target_id=task_id)
-        rel_address2 = addresser.role.task.address(object_id=role_id, target_id=task_id)
+        rel_address1 = addresser.role.task.address(
+            object_id=role_id, related_id=task_id
+        )
+        rel_address2 = addresser.role.task.address(
+            object_id=role_id, related_id=task_id
+        )
         self.assertIsAddress(rel_address1)
         self.assertIsAddress(rel_address2)
         self.assertEqual(rel_address1, rel_address2)
@@ -57,10 +61,10 @@ class TestRoleTaskAddresser(TestAssertions):
         role_id2 = addresser.role.task.unique_id()
         task_id2 = addresser.task.unique_id()
         rel_address1 = addresser.role.task.address(
-            object_id=role_id1, target_id=task_id1
+            object_id=role_id1, related_id=task_id1
         )
         rel_address2 = addresser.role.task.address(
-            object_id=role_id2, target_id=task_id2
+            object_id=role_id2, related_id=task_id2
         )
         self.assertIsAddress(rel_address1)
         self.assertIsAddress(rel_address2)
@@ -79,7 +83,7 @@ class TestRoleTaskAddresser(TestAssertions):
         expected_address = (
             "bac00100005555326a1713a905b26359fc8da26666bbe7570f3f6f7d2c1635f6deea00"
         )
-        rel_address = addresser.role.task.address(object_id=role_id, target_id=task_id)
+        rel_address = addresser.role.task.address(object_id=role_id, related_id=task_id)
         self.assertIsAddress(rel_address)
         self.assertEqual(rel_address, expected_address)
         self.assertEqual(

--- a/tests/rbac/common/addresser/task_admin_test.py
+++ b/tests/rbac/common/addresser/task_admin_test.py
@@ -31,7 +31,9 @@ class TestTaskAdminAddresser(TestAssertions):
         """Tests address makes an address that identifies as the correct AddressSpace"""
         task_id = addresser.task.admin.unique_id()
         user_id = addresser.user.unique_id()
-        rel_address = addresser.task.admin.address(object_id=task_id, target_id=user_id)
+        rel_address = addresser.task.admin.address(
+            object_id=task_id, related_id=user_id
+        )
         self.assertIsAddress(rel_address)
         self.assertEqual(
             addresser.address_is(rel_address), addresser.AddressSpace.TASKS_ADMINS
@@ -42,10 +44,10 @@ class TestTaskAdminAddresser(TestAssertions):
         task_id = addresser.task.admin.unique_id()
         user_id = addresser.user.unique_id()
         rel_address1 = addresser.task.admin.address(
-            object_id=task_id, target_id=user_id
+            object_id=task_id, related_id=user_id
         )
         rel_address2 = addresser.task.admin.address(
-            object_id=task_id, target_id=user_id
+            object_id=task_id, related_id=user_id
         )
         self.assertIsAddress(rel_address1)
         self.assertIsAddress(rel_address2)
@@ -61,10 +63,10 @@ class TestTaskAdminAddresser(TestAssertions):
         task_id2 = addresser.task.admin.unique_id()
         user_id2 = addresser.user.unique_id()
         rel_address1 = addresser.task.admin.address(
-            object_id=task_id1, target_id=user_id1
+            object_id=task_id1, related_id=user_id1
         )
         rel_address2 = addresser.task.admin.address(
-            object_id=task_id2, target_id=user_id2
+            object_id=task_id2, related_id=user_id2
         )
         self.assertIsAddress(rel_address1)
         self.assertIsAddress(rel_address2)
@@ -83,7 +85,9 @@ class TestTaskAdminAddresser(TestAssertions):
         expected_address = (
             "bac00100006666326a1713a905b26359fc8da23333eee7570f3f6f7d2c1635f6deea00"
         )
-        rel_address = addresser.task.admin.address(object_id=task_id, target_id=user_id)
+        rel_address = addresser.task.admin.address(
+            object_id=task_id, related_id=user_id
+        )
         self.assertIsAddress(rel_address)
         self.assertEqual(rel_address, expected_address)
         self.assertEqual(

--- a/tests/rbac/common/addresser/task_owner_test.py
+++ b/tests/rbac/common/addresser/task_owner_test.py
@@ -31,7 +31,9 @@ class TestTaskOwnerAddresser(TestAssertions):
         """Tests address makes an address that identifies as the correct AddressSpace"""
         task_id = addresser.task.owner.unique_id()
         user_id = addresser.user.unique_id()
-        rel_address = addresser.task.owner.address(object_id=task_id, target_id=user_id)
+        rel_address = addresser.task.owner.address(
+            object_id=task_id, related_id=user_id
+        )
         self.assertIsAddress(rel_address)
         self.assertEqual(
             addresser.address_is(rel_address), addresser.AddressSpace.TASKS_OWNERS
@@ -42,10 +44,10 @@ class TestTaskOwnerAddresser(TestAssertions):
         task_id = addresser.task.owner.unique_id()
         user_id = addresser.user.unique_id()
         rel_address1 = addresser.task.owner.address(
-            object_id=task_id, target_id=user_id
+            object_id=task_id, related_id=user_id
         )
         rel_address2 = addresser.task.owner.address(
-            object_id=task_id, target_id=user_id
+            object_id=task_id, related_id=user_id
         )
         self.assertIsAddress(rel_address1)
         self.assertIsAddress(rel_address2)
@@ -61,10 +63,10 @@ class TestTaskOwnerAddresser(TestAssertions):
         task_id2 = addresser.task.owner.unique_id()
         user_id2 = addresser.user.unique_id()
         rel_address1 = addresser.task.owner.address(
-            object_id=task_id1, target_id=user_id1
+            object_id=task_id1, related_id=user_id1
         )
         rel_address2 = addresser.task.owner.address(
-            object_id=task_id2, target_id=user_id2
+            object_id=task_id2, related_id=user_id2
         )
         self.assertIsAddress(rel_address1)
         self.assertIsAddress(rel_address2)
@@ -83,7 +85,9 @@ class TestTaskOwnerAddresser(TestAssertions):
         expected_address = (
             "bac00100006666326a1713a905b26359fc8da23333cce7570f3f6f7d2c1635f6deea00"
         )
-        rel_address = addresser.task.owner.address(object_id=task_id, target_id=user_id)
+        rel_address = addresser.task.owner.address(
+            object_id=task_id, related_id=user_id
+        )
         self.assertIsAddress(rel_address)
         self.assertEqual(rel_address, expected_address)
         self.assertEqual(

--- a/tests/rbac/common/addresser/user_test.py
+++ b/tests/rbac/common/addresser/user_test.py
@@ -99,7 +99,7 @@ class TestUserAddresser(TestAssertions):
         )
         self.assertEqual(parsed.address_type, addresser.AddressSpace.USER)
         self.assertEqual(parsed.object_id, user_id)
-        self.assertEqual(parsed.target_id, None)
+        self.assertEqual(parsed.related_id, None)
 
     def test_addresser_parse(self):
         """Test addresser.parse returns a parsed address"""
@@ -114,7 +114,7 @@ class TestUserAddresser(TestAssertions):
         )
         self.assertEqual(parsed.address_type, addresser.AddressSpace.USER)
         self.assertEqual(parsed.object_id, user_id)
-        self.assertEqual(parsed.target_id, None)
+        self.assertEqual(parsed.related_id, None)
 
     def test_parse_other(self):
         """Test that parse returns None if it is not a user address"""

--- a/tests/rbac/common/role/confirm_admin_test.py
+++ b/tests/rbac/common/role/confirm_admin_test.py
@@ -135,14 +135,14 @@ class ConfirmRoleAddAdminTest(TestAssertions):
         message = rbac.role.admin.confirm.make(
             proposal_id=proposal.proposal_id,
             role_id=proposal.object_id,
-            user_id=proposal.target_id,
+            user_id=proposal.related_id,
             reason=reason,
         )
         confirm, status = rbac.role.admin.confirm.create(
             signer_keypair=role_admin_key,
             message=message,
             object_id=proposal.object_id,
-            target_id=proposal.target_id,
+            related_id=proposal.related_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(confirm, protobuf.proposal_state_pb2.Proposal)
@@ -151,11 +151,11 @@ class ConfirmRoleAddAdminTest(TestAssertions):
         )
         self.assertEqual(confirm.proposal_id, proposal.proposal_id)
         self.assertEqual(confirm.object_id, proposal.object_id)
-        self.assertEqual(confirm.target_id, proposal.target_id)
+        self.assertEqual(confirm.related_id, proposal.related_id)
         self.assertEqual(confirm.close_reason, reason)
         self.assertEqual(confirm.status, protobuf.proposal_state_pb2.Proposal.CONFIRMED)
         self.assertTrue(
             rbac.role.admin.exists(
-                object_id=proposal.object_id, target_id=proposal.target_id
+                object_id=proposal.object_id, related_id=proposal.related_id
             )
         )

--- a/tests/rbac/common/role/confirm_member_test.py
+++ b/tests/rbac/common/role/confirm_member_test.py
@@ -144,14 +144,14 @@ class ConfirmRoleAddMemberTest(TestAssertions):
         message = rbac.role.member.confirm.make(
             proposal_id=proposal.proposal_id,
             role_id=proposal.object_id,
-            user_id=proposal.target_id,
+            user_id=proposal.related_id,
             reason=reason,
         )
         confirm, status = rbac.role.member.confirm.create(
             signer_keypair=role_owner_key,
             message=message,
             object_id=proposal.object_id,
-            target_id=proposal.target_id,
+            related_id=proposal.related_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(confirm, protobuf.proposal_state_pb2.Proposal)
@@ -160,11 +160,11 @@ class ConfirmRoleAddMemberTest(TestAssertions):
         )
         self.assertEqual(confirm.proposal_id, proposal.proposal_id)
         self.assertEqual(confirm.object_id, proposal.object_id)
-        self.assertEqual(confirm.target_id, proposal.target_id)
+        self.assertEqual(confirm.related_id, proposal.related_id)
         self.assertEqual(confirm.close_reason, reason)
         self.assertEqual(confirm.status, protobuf.proposal_state_pb2.Proposal.CONFIRMED)
         self.assertTrue(
             rbac.role.member.exists(
-                object_id=proposal.object_id, target_id=proposal.target_id
+                object_id=proposal.object_id, related_id=proposal.related_id
             )
         )

--- a/tests/rbac/common/role/confirm_owner_test.py
+++ b/tests/rbac/common/role/confirm_owner_test.py
@@ -144,14 +144,14 @@ class ConfirmRoleAddOwnerTest(TestAssertions):
         message = rbac.role.owner.confirm.make(
             proposal_id=proposal.proposal_id,
             role_id=proposal.object_id,
-            user_id=proposal.target_id,
+            user_id=proposal.related_id,
             reason=reason,
         )
         confirm, status = rbac.role.owner.confirm.create(
             signer_keypair=role_owner_key,
             message=message,
             object_id=proposal.object_id,
-            target_id=proposal.target_id,
+            related_id=proposal.related_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(confirm, protobuf.proposal_state_pb2.Proposal)
@@ -160,11 +160,11 @@ class ConfirmRoleAddOwnerTest(TestAssertions):
         )
         self.assertEqual(confirm.proposal_id, proposal.proposal_id)
         self.assertEqual(confirm.object_id, proposal.object_id)
-        self.assertEqual(confirm.target_id, proposal.target_id)
+        self.assertEqual(confirm.related_id, proposal.related_id)
         self.assertEqual(confirm.close_reason, reason)
         self.assertEqual(confirm.status, protobuf.proposal_state_pb2.Proposal.CONFIRMED)
         self.assertTrue(
             rbac.role.owner.exists(
-                object_id=proposal.object_id, target_id=proposal.target_id
+                object_id=proposal.object_id, related_id=proposal.related_id
             )
         )

--- a/tests/rbac/common/role/confirm_task_test.py
+++ b/tests/rbac/common/role/confirm_task_test.py
@@ -127,14 +127,14 @@ class ConfirmRoleAddTaskTest(TestAssertions):
         message = rbac.role.task.confirm.make(
             proposal_id=proposal.proposal_id,
             role_id=proposal.object_id,
-            task_id=proposal.target_id,
+            task_id=proposal.related_id,
             reason=reason,
         )
         confirm, status = rbac.role.task.confirm.create(
             signer_keypair=task_owner_key,
             message=message,
             object_id=proposal.object_id,
-            target_id=proposal.target_id,
+            related_id=proposal.related_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(confirm, protobuf.proposal_state_pb2.Proposal)
@@ -143,11 +143,11 @@ class ConfirmRoleAddTaskTest(TestAssertions):
         )
         self.assertEqual(confirm.proposal_id, proposal.proposal_id)
         self.assertEqual(confirm.object_id, proposal.object_id)
-        self.assertEqual(confirm.target_id, proposal.target_id)
+        self.assertEqual(confirm.related_id, proposal.related_id)
         self.assertEqual(confirm.close_reason, reason)
         self.assertEqual(confirm.status, protobuf.proposal_state_pb2.Proposal.CONFIRMED)
         self.assertTrue(
             rbac.role.task.exists(
-                object_id=proposal.object_id, target_id=proposal.target_id
+                object_id=proposal.object_id, related_id=proposal.related_id
             )
         )

--- a/tests/rbac/common/role/create_role_helper.py
+++ b/tests/rbac/common/role/create_role_helper.py
@@ -81,9 +81,9 @@ class CreateRoleTestHelper(TestAssertions):
         self.assertStatusSuccess(status)
         self.assertEqualMessage(role, message, rbac.role.message_fields_not_in_state)
         self.assertTrue(
-            rbac.role.owner.exists(object_id=role.role_id, target_id=user.user_id)
+            rbac.role.owner.exists(object_id=role.role_id, related_id=user.user_id)
         )
         self.assertTrue(
-            rbac.role.admin.exists(object_id=role.role_id, target_id=user.user_id)
+            rbac.role.admin.exists(object_id=role.role_id, related_id=user.user_id)
         )
         return role, user, keypair

--- a/tests/rbac/common/role/create_role_test.py
+++ b/tests/rbac/common/role/create_role_test.py
@@ -129,8 +129,8 @@ class CreateRoleTest(TestAssertions):
         self.assertStatusSuccess(status)
         self.assertEqualMessage(role, message, rbac.role.message_fields_not_in_state)
         self.assertTrue(
-            rbac.role.owner.exists(object_id=role.role_id, target_id=user.user_id)
+            rbac.role.owner.exists(object_id=role.role_id, related_id=user.user_id)
         )
         self.assertTrue(
-            rbac.role.admin.exists(object_id=role.role_id, target_id=user.user_id)
+            rbac.role.admin.exists(object_id=role.role_id, related_id=user.user_id)
         )

--- a/tests/rbac/common/role/propose_admin_helper.py
+++ b/tests/rbac/common/role/propose_admin_helper.py
@@ -69,7 +69,7 @@ class ProposeRoleAdminTestHelper(TestAssertions):
             signer_keypair=user_key,
             message=message,
             object_id=role.role_id,
-            target_id=user.user_id,
+            related_id=user.user_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(proposal, protobuf.proposal_state_pb2.Proposal)
@@ -78,7 +78,7 @@ class ProposeRoleAdminTestHelper(TestAssertions):
         )
         self.assertEqual(proposal.proposal_id, proposal_id)
         self.assertEqual(proposal.object_id, role.role_id)
-        self.assertEqual(proposal.target_id, user.user_id)
+        self.assertEqual(proposal.related_id, user.user_id)
         self.assertEqual(proposal.opener, user.user_id)
         self.assertEqual(proposal.open_reason, reason)
         return proposal, role, role_owner, role_owner_key, user, user_key

--- a/tests/rbac/common/role/propose_admin_helper_test.py
+++ b/tests/rbac/common/role/propose_admin_helper_test.py
@@ -68,4 +68,4 @@ class ProposeRoleAdminHelperTest(TestAssertions):
         self.assertIsInstance(user_key, Key)
         self.assertIsInstance(role_owner_key, Key)
         self.assertEqual(proposal.object_id, role.role_id)
-        self.assertEqual(proposal.target_id, user.user_id)
+        self.assertEqual(proposal.related_id, user.user_id)

--- a/tests/rbac/common/role/propose_admin_test.py
+++ b/tests/rbac/common/role/propose_admin_test.py
@@ -143,7 +143,7 @@ class ProposeRoleAddAdminTest(TestAssertions):
             signer_keypair=signer_keypair,
             message=message,
             object_id=role.role_id,
-            target_id=user.user_id,
+            related_id=user.user_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(proposal, protobuf.proposal_state_pb2.Proposal)
@@ -152,6 +152,6 @@ class ProposeRoleAddAdminTest(TestAssertions):
         )
         self.assertEqual(proposal.proposal_id, proposal_id)
         self.assertEqual(proposal.object_id, role.role_id)
-        self.assertEqual(proposal.target_id, user.user_id)
+        self.assertEqual(proposal.related_id, user.user_id)
         self.assertEqual(proposal.opener, signer_keypair.public_key)
         self.assertEqual(proposal.open_reason, reason)

--- a/tests/rbac/common/role/propose_member_helper.py
+++ b/tests/rbac/common/role/propose_member_helper.py
@@ -70,7 +70,7 @@ class ProposeRoleMemberTestHelper(TestAssertions):
             signer_keypair=user_key,
             message=message,
             object_id=role.role_id,
-            target_id=user.user_id,
+            related_id=user.user_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(proposal, protobuf.proposal_state_pb2.Proposal)
@@ -79,7 +79,7 @@ class ProposeRoleMemberTestHelper(TestAssertions):
         )
         self.assertEqual(proposal.proposal_id, proposal_id)
         self.assertEqual(proposal.object_id, role.role_id)
-        self.assertEqual(proposal.target_id, user.user_id)
+        self.assertEqual(proposal.related_id, user.user_id)
         self.assertEqual(proposal.opener, user.user_id)
         self.assertEqual(proposal.open_reason, reason)
         return proposal, role, role_owner, role_owner_key, user, user_key

--- a/tests/rbac/common/role/propose_member_helper_test.py
+++ b/tests/rbac/common/role/propose_member_helper_test.py
@@ -67,4 +67,4 @@ class ProposeRoleMemberHelperTest(TestAssertions):
         self.assertIsInstance(user_key, Key)
         self.assertIsInstance(role_owner_key, Key)
         self.assertEqual(proposal.object_id, role.role_id)
-        self.assertEqual(proposal.target_id, user.user_id)
+        self.assertEqual(proposal.related_id, user.user_id)

--- a/tests/rbac/common/role/propose_member_test.py
+++ b/tests/rbac/common/role/propose_member_test.py
@@ -142,7 +142,7 @@ class ProposeRoleAddMemberTest(TestAssertions):
             signer_keypair=signer_keypair,
             message=message,
             object_id=role.role_id,
-            target_id=user.user_id,
+            related_id=user.user_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(proposal, protobuf.proposal_state_pb2.Proposal)
@@ -151,6 +151,6 @@ class ProposeRoleAddMemberTest(TestAssertions):
         )
         self.assertEqual(proposal.proposal_id, proposal_id)
         self.assertEqual(proposal.object_id, role.role_id)
-        self.assertEqual(proposal.target_id, user.user_id)
+        self.assertEqual(proposal.related_id, user.user_id)
         self.assertEqual(proposal.opener, signer_keypair.public_key)
         self.assertEqual(proposal.open_reason, reason)

--- a/tests/rbac/common/role/propose_owner_helper.py
+++ b/tests/rbac/common/role/propose_owner_helper.py
@@ -69,7 +69,7 @@ class ProposeRoleOwnerTestHelper(TestAssertions):
             signer_keypair=user_key,
             message=message,
             object_id=role.role_id,
-            target_id=user.user_id,
+            related_id=user.user_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(proposal, protobuf.proposal_state_pb2.Proposal)
@@ -78,7 +78,7 @@ class ProposeRoleOwnerTestHelper(TestAssertions):
         )
         self.assertEqual(proposal.proposal_id, proposal_id)
         self.assertEqual(proposal.object_id, role.role_id)
-        self.assertEqual(proposal.target_id, user.user_id)
+        self.assertEqual(proposal.related_id, user.user_id)
         self.assertEqual(proposal.opener, user.user_id)
         self.assertEqual(proposal.open_reason, reason)
         return proposal, role, role_owner, role_owner_key, user, user_key

--- a/tests/rbac/common/role/propose_owner_helper_test.py
+++ b/tests/rbac/common/role/propose_owner_helper_test.py
@@ -66,4 +66,4 @@ class ProposeRoleOwnerHelperTest(TestAssertions):
         self.assertIsInstance(user_key, Key)
         self.assertIsInstance(role_owner_key, Key)
         self.assertEqual(proposal.object_id, role.role_id)
-        self.assertEqual(proposal.target_id, user.user_id)
+        self.assertEqual(proposal.related_id, user.user_id)

--- a/tests/rbac/common/role/propose_owner_test.py
+++ b/tests/rbac/common/role/propose_owner_test.py
@@ -142,7 +142,7 @@ class ProposeRoleAddOwnerTest(TestAssertions):
             signer_keypair=signer_keypair,
             message=message,
             object_id=role.role_id,
-            target_id=user.user_id,
+            related_id=user.user_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(proposal, protobuf.proposal_state_pb2.Proposal)
@@ -151,6 +151,6 @@ class ProposeRoleAddOwnerTest(TestAssertions):
         )
         self.assertEqual(proposal.proposal_id, proposal_id)
         self.assertEqual(proposal.object_id, role.role_id)
-        self.assertEqual(proposal.target_id, user.user_id)
+        self.assertEqual(proposal.related_id, user.user_id)
         self.assertEqual(proposal.opener, signer_keypair.public_key)
         self.assertEqual(proposal.open_reason, reason)

--- a/tests/rbac/common/role/propose_task_helper.py
+++ b/tests/rbac/common/role/propose_task_helper.py
@@ -68,7 +68,7 @@ class ProposeRoleTaskTestHelper(TestAssertions):
             signer_keypair=role_owner_key,
             message=message,
             object_id=role.role_id,
-            target_id=task.task_id,
+            related_id=task.task_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(proposal, protobuf.proposal_state_pb2.Proposal)
@@ -77,7 +77,7 @@ class ProposeRoleTaskTestHelper(TestAssertions):
         )
         self.assertEqual(proposal.proposal_id, proposal_id)
         self.assertEqual(proposal.object_id, role.role_id)
-        self.assertEqual(proposal.target_id, task.task_id)
+        self.assertEqual(proposal.related_id, task.task_id)
         self.assertEqual(proposal.opener, role_owner_key.public_key)
         self.assertEqual(proposal.open_reason, reason)
         return (

--- a/tests/rbac/common/role/propose_task_helper_test.py
+++ b/tests/rbac/common/role/propose_task_helper_test.py
@@ -68,4 +68,4 @@ class ProposeRoleTaskHelperTest(TestAssertions):
         self.assertIsInstance(role_owner_key, Key)
         self.assertIsInstance(task_owner_key, Key)
         self.assertEqual(proposal.object_id, role.role_id)
-        self.assertEqual(proposal.target_id, task.task_id)
+        self.assertEqual(proposal.related_id, task.task_id)

--- a/tests/rbac/common/role/propose_task_test.py
+++ b/tests/rbac/common/role/propose_task_test.py
@@ -152,7 +152,7 @@ class ProposeRoleAddTaskTest(TestAssertions):
             signer_keypair=role_owner_key,
             message=message,
             object_id=role.role_id,
-            target_id=task.task_id,
+            related_id=task.task_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(proposal, protobuf.proposal_state_pb2.Proposal)
@@ -161,6 +161,6 @@ class ProposeRoleAddTaskTest(TestAssertions):
         )
         self.assertEqual(proposal.proposal_id, proposal_id)
         self.assertEqual(proposal.object_id, role.role_id)
-        self.assertEqual(proposal.target_id, task.task_id)
+        self.assertEqual(proposal.related_id, task.task_id)
         self.assertEqual(proposal.opener, role_owner_key.public_key)
         self.assertEqual(proposal.open_reason, reason)

--- a/tests/rbac/common/role/reject_admin_test.py
+++ b/tests/rbac/common/role/reject_admin_test.py
@@ -121,14 +121,14 @@ class RejectRoleAddAdminTest(TestAssertions):
         message = rbac.role.admin.reject.make(
             proposal_id=proposal.proposal_id,
             role_id=proposal.object_id,
-            user_id=proposal.target_id,
+            user_id=proposal.related_id,
             reason=reason,
         )
         reject, status = rbac.role.admin.reject.create(
             signer_keypair=role_admin_key,
             message=message,
             object_id=proposal.object_id,
-            target_id=proposal.target_id,
+            related_id=proposal.related_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(reject, protobuf.proposal_state_pb2.Proposal)
@@ -137,7 +137,7 @@ class RejectRoleAddAdminTest(TestAssertions):
         )
         self.assertEqual(reject.proposal_id, proposal.proposal_id)
         self.assertEqual(reject.object_id, proposal.object_id)
-        self.assertEqual(reject.target_id, proposal.target_id)
+        self.assertEqual(reject.related_id, proposal.related_id)
         self.assertEqual(reject.close_reason, reason)
         self.assertEqual(reject.closer, role_admin_key.public_key)
         self.assertEqual(reject.status, protobuf.proposal_state_pb2.Proposal.REJECTED)

--- a/tests/rbac/common/role/reject_member_test.py
+++ b/tests/rbac/common/role/reject_member_test.py
@@ -131,14 +131,14 @@ class RejectRoleAddMemberTest(TestAssertions):
         message = rbac.role.member.reject.make(
             proposal_id=proposal.proposal_id,
             role_id=proposal.object_id,
-            user_id=proposal.target_id,
+            user_id=proposal.related_id,
             reason=reason,
         )
         reject, status = rbac.role.member.reject.create(
             signer_keypair=role_owner_key,
             message=message,
             object_id=proposal.object_id,
-            target_id=proposal.target_id,
+            related_id=proposal.related_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(reject, protobuf.proposal_state_pb2.Proposal)
@@ -147,7 +147,7 @@ class RejectRoleAddMemberTest(TestAssertions):
         )
         self.assertEqual(reject.proposal_id, proposal.proposal_id)
         self.assertEqual(reject.object_id, proposal.object_id)
-        self.assertEqual(reject.target_id, proposal.target_id)
+        self.assertEqual(reject.related_id, proposal.related_id)
         self.assertEqual(reject.close_reason, reason)
         self.assertEqual(reject.closer, role_owner_key.public_key)
         self.assertEqual(reject.status, protobuf.proposal_state_pb2.Proposal.REJECTED)

--- a/tests/rbac/common/role/reject_owner_test.py
+++ b/tests/rbac/common/role/reject_owner_test.py
@@ -134,14 +134,14 @@ class RejectRoleAddOwnerTest(TestAssertions):
         message = rbac.role.owner.reject.make(
             proposal_id=proposal.proposal_id,
             role_id=proposal.object_id,
-            user_id=proposal.target_id,
+            user_id=proposal.related_id,
             reason=reason,
         )
         reject, status = rbac.role.owner.reject.create(
             signer_keypair=role_owner_key,
             message=message,
             object_id=proposal.object_id,
-            target_id=proposal.target_id,
+            related_id=proposal.related_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(reject, protobuf.proposal_state_pb2.Proposal)
@@ -150,7 +150,7 @@ class RejectRoleAddOwnerTest(TestAssertions):
         )
         self.assertEqual(reject.proposal_id, proposal.proposal_id)
         self.assertEqual(reject.object_id, proposal.object_id)
-        self.assertEqual(reject.target_id, proposal.target_id)
+        self.assertEqual(reject.related_id, proposal.related_id)
         self.assertEqual(reject.close_reason, reason)
         self.assertEqual(reject.closer, role_owner_key.public_key)
         self.assertEqual(reject.status, protobuf.proposal_state_pb2.Proposal.REJECTED)

--- a/tests/rbac/common/role/reject_task_test.py
+++ b/tests/rbac/common/role/reject_task_test.py
@@ -121,14 +121,14 @@ class RejectRoleAddTaskTest(TestAssertions):
         message = rbac.role.task.reject.make(
             proposal_id=proposal.proposal_id,
             role_id=proposal.object_id,
-            task_id=proposal.target_id,
+            task_id=proposal.related_id,
             reason=reason,
         )
         reject, status = rbac.role.task.reject.create(
             signer_keypair=task_owner_key,
             message=message,
             object_id=proposal.object_id,
-            target_id=proposal.target_id,
+            related_id=proposal.related_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(reject, protobuf.proposal_state_pb2.Proposal)
@@ -137,7 +137,7 @@ class RejectRoleAddTaskTest(TestAssertions):
         )
         self.assertEqual(reject.proposal_id, proposal.proposal_id)
         self.assertEqual(reject.object_id, proposal.object_id)
-        self.assertEqual(reject.target_id, proposal.target_id)
+        self.assertEqual(reject.related_id, proposal.related_id)
         self.assertEqual(reject.close_reason, reason)
         self.assertEqual(reject.closer, task_owner_key.public_key)
         self.assertEqual(reject.status, protobuf.proposal_state_pb2.Proposal.REJECTED)

--- a/tests/rbac/common/task/confirm_admin_test.py
+++ b/tests/rbac/common/task/confirm_admin_test.py
@@ -134,7 +134,7 @@ class ConfirmTaskAddAdminTest(TestAssertions):
         message = rbac.task.admin.confirm.make(
             proposal_id=proposal.proposal_id,
             task_id=proposal.object_id,
-            user_id=proposal.target_id,
+            user_id=proposal.related_id,
             reason=reason,
         )
         _, status = rbac.task.admin.confirm.create(
@@ -142,7 +142,7 @@ class ConfirmTaskAddAdminTest(TestAssertions):
         )
         self.assertStatusSuccess(status)
         confirm = rbac.task.admin.confirm.get(
-            object_id=proposal.object_id, target_id=proposal.target_id
+            object_id=proposal.object_id, related_id=proposal.related_id
         )
         self.assertIsInstance(confirm, protobuf.proposal_state_pb2.Proposal)
         self.assertEqual(
@@ -150,11 +150,11 @@ class ConfirmTaskAddAdminTest(TestAssertions):
         )
         self.assertEqual(confirm.proposal_id, proposal.proposal_id)
         self.assertEqual(confirm.object_id, proposal.object_id)
-        self.assertEqual(confirm.target_id, proposal.target_id)
+        self.assertEqual(confirm.related_id, proposal.related_id)
         self.assertEqual(confirm.close_reason, reason)
         self.assertEqual(confirm.status, protobuf.proposal_state_pb2.Proposal.CONFIRMED)
         self.assertTrue(
             rbac.task.admin.exists(
-                object_id=proposal.object_id, target_id=proposal.target_id
+                object_id=proposal.object_id, related_id=proposal.related_id
             )
         )

--- a/tests/rbac/common/task/confirm_owner_test.py
+++ b/tests/rbac/common/task/confirm_owner_test.py
@@ -143,7 +143,7 @@ class ConfirmTaskAddOwnerTest(TestAssertions):
         message = rbac.task.owner.confirm.make(
             proposal_id=proposal.proposal_id,
             task_id=proposal.object_id,
-            user_id=proposal.target_id,
+            user_id=proposal.related_id,
             reason=reason,
         )
         _, status = rbac.task.owner.confirm.create(
@@ -151,7 +151,7 @@ class ConfirmTaskAddOwnerTest(TestAssertions):
         )
         self.assertStatusSuccess(status)
         confirm = rbac.task.owner.confirm.get(
-            object_id=proposal.object_id, target_id=proposal.target_id
+            object_id=proposal.object_id, related_id=proposal.related_id
         )
         self.assertIsInstance(confirm, protobuf.proposal_state_pb2.Proposal)
         self.assertEqual(
@@ -159,11 +159,11 @@ class ConfirmTaskAddOwnerTest(TestAssertions):
         )
         self.assertEqual(confirm.proposal_id, proposal.proposal_id)
         self.assertEqual(confirm.object_id, proposal.object_id)
-        self.assertEqual(confirm.target_id, proposal.target_id)
+        self.assertEqual(confirm.related_id, proposal.related_id)
         self.assertEqual(confirm.close_reason, reason)
         self.assertEqual(confirm.status, protobuf.proposal_state_pb2.Proposal.CONFIRMED)
         self.assertTrue(
             rbac.task.owner.exists(
-                object_id=proposal.object_id, target_id=proposal.target_id
+                object_id=proposal.object_id, related_id=proposal.related_id
             )
         )

--- a/tests/rbac/common/task/create_task_helper.py
+++ b/tests/rbac/common/task/create_task_helper.py
@@ -81,9 +81,9 @@ class CreateTaskTestHelper(TestAssertions):
         task = rbac.task.get(object_id=message.task_id)
         self.assertEqualMessage(task, message, rbac.task.message_fields_not_in_state)
         self.assertTrue(
-            rbac.task.owner.exists(object_id=task.task_id, target_id=user.user_id)
+            rbac.task.owner.exists(object_id=task.task_id, related_id=user.user_id)
         )
         self.assertTrue(
-            rbac.task.admin.exists(object_id=task.task_id, target_id=user.user_id)
+            rbac.task.admin.exists(object_id=task.task_id, related_id=user.user_id)
         )
         return task, user, keypair

--- a/tests/rbac/common/task/create_task_test.py
+++ b/tests/rbac/common/task/create_task_test.py
@@ -127,10 +127,10 @@ class CreateTaskTest(TestAssertions):
         task = rbac.task.get(object_id=task_id)
         self.assertEqualMessage(task, message, rbac.task.message_fields_not_in_state)
         self.assertTrue(
-            rbac.task.owner.exists(object_id=task.task_id, target_id=user.user_id)
+            rbac.task.owner.exists(object_id=task.task_id, related_id=user.user_id)
         )
         self.assertTrue(
-            rbac.task.admin.exists(object_id=task.task_id, target_id=user.user_id)
+            rbac.task.admin.exists(object_id=task.task_id, related_id=user.user_id)
         )
 
     @pytest.mark.create_task2
@@ -152,14 +152,14 @@ class CreateTaskTest(TestAssertions):
         task = rbac.task.get(object_id=task_id)
         self.assertEqualMessage(task, message, rbac.task.message_fields_not_in_state)
         self.assertTrue(
-            rbac.task.owner.exists(object_id=task.task_id, target_id=user.user_id)
+            rbac.task.owner.exists(object_id=task.task_id, related_id=user.user_id)
         )
         self.assertTrue(
-            rbac.task.admin.exists(object_id=task.task_id, target_id=user.user_id)
+            rbac.task.admin.exists(object_id=task.task_id, related_id=user.user_id)
         )
         self.assertTrue(
-            rbac.task.owner.exists(object_id=task.task_id, target_id=user2.user_id)
+            rbac.task.owner.exists(object_id=task.task_id, related_id=user2.user_id)
         )
         self.assertTrue(
-            rbac.task.admin.exists(object_id=task.task_id, target_id=user2.user_id)
+            rbac.task.admin.exists(object_id=task.task_id, related_id=user2.user_id)
         )

--- a/tests/rbac/common/task/propose_admin_helper.py
+++ b/tests/rbac/common/task/propose_admin_helper.py
@@ -68,7 +68,7 @@ class ProposeTaskAdminTestHelper(TestAssertions):
             signer_keypair=user_key,
             message=message,
             object_id=task.task_id,
-            target_id=user.user_id,
+            related_id=user.user_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(proposal, protobuf.proposal_state_pb2.Proposal)
@@ -77,7 +77,7 @@ class ProposeTaskAdminTestHelper(TestAssertions):
         )
         self.assertEqual(proposal.proposal_id, proposal_id)
         self.assertEqual(proposal.object_id, task.task_id)
-        self.assertEqual(proposal.target_id, user.user_id)
+        self.assertEqual(proposal.related_id, user.user_id)
         self.assertEqual(proposal.opener, user.user_id)
         self.assertEqual(proposal.open_reason, reason)
         return proposal, task, task_owner, task_owner_key, user, user_key

--- a/tests/rbac/common/task/propose_admin_helper_test.py
+++ b/tests/rbac/common/task/propose_admin_helper_test.py
@@ -66,4 +66,4 @@ class ProposeTaskAdminHelperTest(TestAssertions):
         self.assertIsInstance(user_key, Key)
         self.assertIsInstance(task_owner_key, Key)
         self.assertEqual(proposal.object_id, task.task_id)
-        self.assertEqual(proposal.target_id, user.user_id)
+        self.assertEqual(proposal.related_id, user.user_id)

--- a/tests/rbac/common/task/propose_admin_test.py
+++ b/tests/rbac/common/task/propose_admin_test.py
@@ -141,7 +141,7 @@ class ProposeTaskAddAdminTest(TestAssertions):
         )
         self.assertStatusSuccess(status)
         proposal = rbac.task.admin.propose.get(
-            object_id=task.task_id, target_id=user.user_id
+            object_id=task.task_id, related_id=user.user_id
         )
         self.assertIsInstance(proposal, protobuf.proposal_state_pb2.Proposal)
         self.assertEqual(
@@ -149,6 +149,6 @@ class ProposeTaskAddAdminTest(TestAssertions):
         )
         self.assertEqual(proposal.proposal_id, proposal_id)
         self.assertEqual(proposal.object_id, task.task_id)
-        self.assertEqual(proposal.target_id, user.user_id)
+        self.assertEqual(proposal.related_id, user.user_id)
         self.assertEqual(proposal.opener, signer_keypair.public_key)
         self.assertEqual(proposal.open_reason, reason)

--- a/tests/rbac/common/task/propose_owner_helper.py
+++ b/tests/rbac/common/task/propose_owner_helper.py
@@ -69,7 +69,7 @@ class ProposeTaskOwnerTestHelper(TestAssertions):
             signer_keypair=user_key,
             message=message,
             object_id=task.task_id,
-            target_id=user.user_id,
+            related_id=user.user_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(proposal, protobuf.proposal_state_pb2.Proposal)
@@ -78,7 +78,7 @@ class ProposeTaskOwnerTestHelper(TestAssertions):
         )
         self.assertEqual(proposal.proposal_id, proposal_id)
         self.assertEqual(proposal.object_id, task.task_id)
-        self.assertEqual(proposal.target_id, user.user_id)
+        self.assertEqual(proposal.related_id, user.user_id)
         self.assertEqual(proposal.opener, user.user_id)
         self.assertEqual(proposal.open_reason, reason)
         return proposal, task, task_owner, task_owner_key, user, user_key

--- a/tests/rbac/common/task/propose_owner_helper_test.py
+++ b/tests/rbac/common/task/propose_owner_helper_test.py
@@ -67,4 +67,4 @@ class ProposeTaskOwnerHelperTest(TestAssertions):
         self.assertIsInstance(user_key, Key)
         self.assertIsInstance(task_owner_key, Key)
         self.assertEqual(proposal.object_id, task.task_id)
-        self.assertEqual(proposal.target_id, user.user_id)
+        self.assertEqual(proposal.related_id, user.user_id)

--- a/tests/rbac/common/task/propose_owner_test.py
+++ b/tests/rbac/common/task/propose_owner_test.py
@@ -142,7 +142,7 @@ class ProposeTaskAddOwnerTest(TestAssertions):
             signer_keypair=signer_keypair,
             message=message,
             object_id=task.task_id,
-            target_id=user.user_id,
+            related_id=user.user_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(proposal, protobuf.proposal_state_pb2.Proposal)
@@ -151,6 +151,6 @@ class ProposeTaskAddOwnerTest(TestAssertions):
         )
         self.assertEqual(proposal.proposal_id, proposal_id)
         self.assertEqual(proposal.object_id, task.task_id)
-        self.assertEqual(proposal.target_id, user.user_id)
+        self.assertEqual(proposal.related_id, user.user_id)
         self.assertEqual(proposal.opener, signer_keypair.public_key)
         self.assertEqual(proposal.open_reason, reason)

--- a/tests/rbac/common/task/reject_admin_test.py
+++ b/tests/rbac/common/task/reject_admin_test.py
@@ -121,14 +121,14 @@ class RejectTaskAddAdminTest(TestAssertions):
         message = rbac.task.admin.reject.make(
             proposal_id=proposal.proposal_id,
             task_id=proposal.object_id,
-            user_id=proposal.target_id,
+            user_id=proposal.related_id,
             reason=reason,
         )
         reject, status = rbac.task.admin.reject.create(
             signer_keypair=task_admin_key,
             message=message,
             object_id=proposal.object_id,
-            target_id=proposal.target_id,
+            related_id=proposal.related_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(reject, protobuf.proposal_state_pb2.Proposal)
@@ -137,7 +137,7 @@ class RejectTaskAddAdminTest(TestAssertions):
         )
         self.assertEqual(reject.proposal_id, proposal.proposal_id)
         self.assertEqual(reject.object_id, proposal.object_id)
-        self.assertEqual(reject.target_id, proposal.target_id)
+        self.assertEqual(reject.related_id, proposal.related_id)
         self.assertEqual(reject.close_reason, reason)
         self.assertEqual(reject.closer, task_admin_key.public_key)
         self.assertEqual(reject.status, protobuf.proposal_state_pb2.Proposal.REJECTED)

--- a/tests/rbac/common/task/reject_owner_test.py
+++ b/tests/rbac/common/task/reject_owner_test.py
@@ -128,14 +128,14 @@ class RejectTaskAddOwnerTest(TestAssertions):
         message = rbac.task.owner.reject.make(
             proposal_id=proposal.proposal_id,
             task_id=proposal.object_id,
-            user_id=proposal.target_id,
+            user_id=proposal.related_id,
             reason=reason,
         )
         reject, status = rbac.task.owner.reject.create(
             signer_keypair=task_owner_key,
             message=message,
             object_id=proposal.object_id,
-            target_id=proposal.target_id,
+            related_id=proposal.related_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(reject, protobuf.proposal_state_pb2.Proposal)
@@ -144,7 +144,7 @@ class RejectTaskAddOwnerTest(TestAssertions):
         )
         self.assertEqual(reject.proposal_id, proposal.proposal_id)
         self.assertEqual(reject.object_id, proposal.object_id)
-        self.assertEqual(reject.target_id, proposal.target_id)
+        self.assertEqual(reject.related_id, proposal.related_id)
         self.assertEqual(reject.close_reason, reason)
         self.assertEqual(reject.closer, task_owner_key.public_key)
         self.assertEqual(reject.status, protobuf.proposal_state_pb2.Proposal.REJECTED)

--- a/tests/rbac/common/user/confirm_manager_good_test.py
+++ b/tests/rbac/common/user/confirm_manager_good_test.py
@@ -62,7 +62,7 @@ class ConfirmManagerTest(TestAssertions):
         reason = helper.user.manager.propose.reason()
         proposal_id = helper.proposal.id()
         proposal_address = rbac.user.manager.confirm.address(
-            object_id=user_id, target_id=manager_id
+            object_id=user_id, related_id=manager_id
         )
         signer_user_address = rbac.user.address(signer_keypair.public_key)
         message = rbac.user.manager.confirm.make(
@@ -97,7 +97,7 @@ class ConfirmManagerTest(TestAssertions):
         reason = helper.user.manager.propose.reason()
         proposal_id = helper.proposal.id()
         proposal_address = rbac.user.manager.confirm.address(
-            object_id=user_id, target_id=manager_id
+            object_id=user_id, related_id=manager_id
         )
         signer_user_address = rbac.user.address(signer_keypair.public_key)
         message = rbac.user.manager.confirm.make(
@@ -135,18 +135,18 @@ class ConfirmManagerTest(TestAssertions):
         message = rbac.user.manager.confirm.make(
             proposal_id=proposal.proposal_id,
             user_id=proposal.object_id,
-            manager_id=proposal.target_id,
+            manager_id=proposal.related_id,
             reason=reason,
         )
         _, status = rbac.user.manager.confirm.create(
             signer_keypair=manager_key,
             message=message,
             object_id=proposal.object_id,
-            target_id=proposal.target_id,
+            related_id=proposal.related_id,
         )
         self.assertStatusSuccess(status)
         confirm = rbac.user.manager.confirm.get(
-            object_id=proposal.object_id, target_id=proposal.target_id
+            object_id=proposal.object_id, related_id=proposal.related_id
         )
         self.assertIsInstance(confirm, protobuf.proposal_state_pb2.Proposal)
         self.assertEqual(
@@ -155,9 +155,9 @@ class ConfirmManagerTest(TestAssertions):
         )
         self.assertEqual(confirm.proposal_id, proposal.proposal_id)
         self.assertEqual(confirm.object_id, proposal.object_id)
-        self.assertEqual(confirm.target_id, proposal.target_id)
+        self.assertEqual(confirm.related_id, proposal.related_id)
         self.assertEqual(confirm.close_reason, reason)
         self.assertEqual(confirm.status, protobuf.proposal_state_pb2.Proposal.CONFIRMED)
         user = rbac.user.get(object_id=proposal.object_id)
         self.assertIsInstance(user, protobuf.user_state_pb2.User)
-        self.assertEqual(user.manager_id, proposal.target_id)
+        self.assertEqual(user.manager_id, proposal.related_id)

--- a/tests/rbac/common/user/propose_manager_good_test.py
+++ b/tests/rbac/common/user/propose_manager_good_test.py
@@ -61,7 +61,7 @@ class ProposeManagerGoodTest(TestAssertions):
         manager_id = helper.user.id()
         manager_address = rbac.user.address(object_id=manager_id)
         proposal_address = rbac.user.manager.propose.address(
-            object_id=user_id, target_id=manager_id
+            object_id=user_id, related_id=manager_id
         )
         signer_user_address = rbac.user.address(user_key.public_key)
         proposal_id = rbac.addresser.proposal.unique_id()
@@ -98,7 +98,7 @@ class ProposeManagerGoodTest(TestAssertions):
         manager_id = helper.user.id()
         manager_address = rbac.user.address(object_id=manager_id)
         proposal_address = rbac.user.manager.propose.address(
-            object_id=user_id, target_id=manager_id
+            object_id=user_id, related_id=manager_id
         )
         signer_user_address = rbac.user.address(user_key.public_key)
         proposal_id = rbac.addresser.proposal.unique_id()
@@ -135,7 +135,7 @@ class ProposeManagerGoodTest(TestAssertions):
         manager_id = helper.user.id()
         manager_address = rbac.user.address(object_id=manager_id)
         proposal_address = rbac.user.manager.propose.address(
-            object_id=user_id, target_id=manager_id
+            object_id=user_id, related_id=manager_id
         )
         signer_keypair = helper.user.key()
         signer_user_address = rbac.user.address(signer_keypair.public_key)
@@ -173,7 +173,7 @@ class ProposeManagerGoodTest(TestAssertions):
         manager_id = helper.user.id()
         manager_address = rbac.user.address(object_id=manager_id)
         proposal_address = rbac.user.manager.propose.address(
-            object_id=user_id, target_id=manager_id
+            object_id=user_id, related_id=manager_id
         )
         signer_user_address = rbac.user.address(user_key.public_key)
         proposal_id = rbac.addresser.proposal.unique_id()
@@ -224,7 +224,7 @@ class ProposeManagerGoodTest(TestAssertions):
             signer_keypair=user_key,
             message=message,
             object_id=user.user_id,
-            target_id=manager.user_id,
+            related_id=manager.user_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(proposal, protobuf.proposal_state_pb2.Proposal)
@@ -234,7 +234,7 @@ class ProposeManagerGoodTest(TestAssertions):
         )
         self.assertEqual(proposal.proposal_id, proposal_id)
         self.assertEqual(proposal.object_id, user.user_id)
-        self.assertEqual(proposal.target_id, manager.user_id)
+        self.assertEqual(proposal.related_id, manager.user_id)
         self.assertEqual(proposal.opener, user.user_id)
         self.assertEqual(proposal.open_reason, reason)
 
@@ -257,7 +257,7 @@ class ProposeManagerGoodTest(TestAssertions):
             signer_keypair=manager_key,
             message=message,
             object_id=user.user_id,
-            target_id=manager.user_id,
+            related_id=manager.user_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(proposal, protobuf.proposal_state_pb2.Proposal)
@@ -267,7 +267,7 @@ class ProposeManagerGoodTest(TestAssertions):
         )
         self.assertEqual(proposal.proposal_id, proposal_id)
         self.assertEqual(proposal.object_id, user.user_id)
-        self.assertEqual(proposal.target_id, manager.user_id)
+        self.assertEqual(proposal.related_id, manager.user_id)
         self.assertEqual(proposal.opener, manager.user_id)
         self.assertEqual(proposal.open_reason, reason)
 
@@ -290,7 +290,7 @@ class ProposeManagerGoodTest(TestAssertions):
             signer_keypair=user_key,
             message=message,
             object_id=proposal.object_id,
-            target_id=new_manager.user_id,
+            related_id=new_manager.user_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(new_proposal, protobuf.proposal_state_pb2.Proposal)
@@ -300,6 +300,6 @@ class ProposeManagerGoodTest(TestAssertions):
         )
         self.assertEqual(new_proposal.proposal_id, proposal_id)
         self.assertEqual(new_proposal.object_id, user.user_id)
-        self.assertEqual(new_proposal.target_id, new_manager.user_id)
+        self.assertEqual(new_proposal.related_id, new_manager.user_id)
         self.assertEqual(new_proposal.opener, user.user_id)
         self.assertEqual(new_proposal.open_reason, reason)

--- a/tests/rbac/common/user/propose_manager_helper.py
+++ b/tests/rbac/common/user/propose_manager_helper.py
@@ -65,7 +65,7 @@ class ProposeManagerTestHelper(TestAssertions):
             signer_keypair=user_key,
             message=message,
             object_id=user.user_id,
-            target_id=manager.user_id,
+            related_id=manager.user_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(proposal, protobuf.proposal_state_pb2.Proposal)
@@ -75,7 +75,7 @@ class ProposeManagerTestHelper(TestAssertions):
         )
         self.assertEqual(proposal.proposal_id, proposal_id)
         self.assertEqual(proposal.object_id, user.user_id)
-        self.assertEqual(proposal.target_id, manager.user_id)
+        self.assertEqual(proposal.related_id, manager.user_id)
         self.assertEqual(proposal.opener, user.user_id)
         self.assertEqual(proposal.open_reason, reason)
         return proposal, user, user_key, manager, manager_key

--- a/tests/rbac/common/user/propose_manager_helper_test.py
+++ b/tests/rbac/common/user/propose_manager_helper_test.py
@@ -64,5 +64,5 @@ class ProposeManagerTestHelperTest(TestAssertions):
         self.assertIsInstance(user_key, Key)
         self.assertIsInstance(manager_key, Key)
         self.assertEqual(proposal.object_id, user.user_id)
-        self.assertEqual(proposal.target_id, manager.user_id)
+        self.assertEqual(proposal.related_id, manager.user_id)
         self.assertEqual(user.manager_id, "")

--- a/tests/rbac/common/user/reject_manager_good_test.py
+++ b/tests/rbac/common/user/reject_manager_good_test.py
@@ -60,7 +60,7 @@ class RejectManagerTest(TestAssertions):
         reason = helper.user.manager.propose.reason()
         proposal_id = helper.user.manager.propose.id()
         proposal_address = rbac.user.manager.reject.address(
-            object_id=user_id, target_id=manager_id
+            object_id=user_id, related_id=manager_id
         )
         signer_user_address = rbac.user.address(user_key.public_key)
         message = rbac.user.manager.reject.make(
@@ -92,7 +92,7 @@ class RejectManagerTest(TestAssertions):
         reason = helper.user.manager.propose.reason()
         proposal_id = helper.user.manager.propose.id()
         proposal_address = rbac.user.manager.reject.address(
-            object_id=user_id, target_id=manager_id
+            object_id=user_id, related_id=manager_id
         )
         signer_user_address = rbac.user.address(user_key.public_key)
         message = rbac.user.manager.reject.make(
@@ -128,14 +128,14 @@ class RejectManagerTest(TestAssertions):
         message = rbac.user.manager.reject.make(
             proposal_id=proposal.proposal_id,
             user_id=proposal.object_id,
-            manager_id=proposal.target_id,
+            manager_id=proposal.related_id,
             reason=reason,
         )
         reject, status = rbac.user.manager.reject.create(
             signer_keypair=manager_key,
             message=message,
             object_id=proposal.object_id,
-            target_id=proposal.target_id,
+            related_id=proposal.related_id,
         )
         self.assertStatusSuccess(status)
         self.assertIsInstance(reject, protobuf.proposal_state_pb2.Proposal)
@@ -145,6 +145,6 @@ class RejectManagerTest(TestAssertions):
         )
         self.assertEqual(reject.proposal_id, proposal.proposal_id)
         self.assertEqual(reject.object_id, proposal.object_id)
-        self.assertEqual(reject.target_id, proposal.target_id)
+        self.assertEqual(reject.related_id, proposal.related_id)
         self.assertEqual(reject.close_reason, reason)
         self.assertEqual(reject.status, protobuf.proposal_state_pb2.Proposal.REJECTED)


### PR DESCRIPTION
Renames target_id to related_id.

Related_id more accurately describes what it is used for and is consistent with new addressing scheme ( object_type / object_id / related_type / relationship_type / related_id )
