### PR TITLE
AAD sync listen / process inbound queue records

### DIFF
--- a/bin/rbac-providers-next
+++ b/bin/rbac-providers-next
@@ -22,6 +22,8 @@ import sys
 TOP_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, TOP_DIR)
 
+from rbac.providers.next.inbound_sync import inbound_sync_listener
+
 # TODO: import required functions from the next provider module.
 # from rbac.providers.next import <my_function>
 
@@ -30,7 +32,9 @@ LOGGER.level = logging.INFO
 LOGGER.addHandler(logging.StreamHandler(sys.stdout))
 
 def main():
-    #TODO: add calls to rbac.providers.next module to kick off listener.
+    """Worker daemon that pull entries from the inbound queue and puts the required
+    changes in Sawtooth."""
+    inbound_sync_listener()
     LOGGER.info("Starting NEXT sync listener.")
 
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,6 +40,24 @@ services:
       - SECRET_KEY=${SECRET_KEY}
       - AES_KEY=${AES_KEY}
 
+  rbac-provider-next:
+    build:
+      context: .
+      dockerfile: ./docker/rbac.providers.next.Dockerfile
+    container_name: rbac-providers-next
+    image: rbac-provider-next:${ISOLATION_ID-latest}
+    volumes:
+      - ".:/project/hyperledger-rbac"
+    environment:
+      - CLIENT_ID=${CLIENT_ID}
+      - CLIENT_SECRET=${CLIENT_SECRET}
+      - CLIENT_ASSERTION=${CLIENT_ASSERTION}
+      - TENANT_ID=${TENANT_ID}
+      - AUTH_TYPE=${AUTH_TYPE}
+    depends_on:
+      - ledger-sync
+    command: ./bin/rbac-providers-next
+
   rbac-provider-azure:
     build:
       context: .

--- a/docker/rbac.providers.azure.Dockerfile
+++ b/docker/rbac.providers.azure.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # -----------------------------------------------------------------------------
-FROM python:3.7
+FROM python:3.5-slim
 
 RUN pip install \
     requests    \

--- a/docker/rbac.providers.ldap.Dockerfile
+++ b/docker/rbac.providers.ldap.Dockerfile
@@ -47,7 +47,8 @@ WORKDIR /project/hyperledger-rbac
 # Container-specific dependencies are installed separately for
 # optimizing caching
 RUN pip3 install \
-        ldap3==2.5.1 \
+        rethinkdb \
+        ldap3 \
         pyasn1==0.4.4 \
         pytz==2018.6
 

--- a/docker/rbac.providers.next.Dockerfile
+++ b/docker/rbac.providers.next.Dockerfile
@@ -13,32 +13,11 @@
 # limitations under the License.
 # -----------------------------------------------------------------------------
 
-# -----------------------------------------------------------------------------
-# Begin base docker image config for Hyperledger RBAC Next Directory
-# This should remain the same for all python containers to maximize caching
-# -----------------------------------------------------------------------------
-FROM hyperledger/sawtooth-validator:1.0
+FROM python:3.5-slim
 
-RUN apt-get update \
- && apt-get install -y --allow-unauthenticated -q \
-        python3-pip \
-        python3-sawtooth-sdk \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install -y  apt-utils
-
-RUN pip3 install -U pip setuptools
-
-RUN pip3 install \
-        grpcio-tools \
-        itsdangerous \
-        sanic==0.7.0
+RUN pip install \
+        rethinkdb 
 
 WORKDIR /project/hyperledger-rbac
-
-# Container-specific dependencies are installed separately for
-# optimizing cacheing
-RUN pip3 install \
-        rethinkdb 
 
 CMD [ "./bin/rbac-providers-next" ]

--- a/rbac/providers/azure/delta_inbound_sync.py
+++ b/rbac/providers/azure/delta_inbound_sync.py
@@ -40,7 +40,7 @@ EVENTHUB_NAME = os.environ.get("AAD_EH_NAME")
 # Address can be in either of these formats:
 # "amqps://<URL-encoded-SAS-policy>:<URL-encoded-SAS-key>@<mynamespace>.servicebus.windows.net/myeventhub"
 # "amqps://<mynamespace>.servicebus.windows.net/myeventhub"
-ADDRESS = f"amqps://{NAMESPACE}.servicebus.windows.net/{EVENTHUB_NAME}"
+ADDRESS = ("amqps://%s.servicebus.windows.net/%s", NAMESPACE, EVENTHUB_NAME)
 
 # SAS policy and key are not required if they are encoded in the URL
 USER = os.environ.get("AAD_EH_SAS_POLICY")

--- a/rbac/providers/azure/delta_outbound_sync.py
+++ b/rbac/providers/azure/delta_outbound_sync.py
@@ -73,7 +73,7 @@ def is_user_in_aad(queue_entry):
         return False
     else:
         raise Exception(
-            f"Error getting user in Azure AD: Status code {response.status_code}"
+            ("Error getting user in Azure AD: Status code %s", response.status_code)
         )
 
 
@@ -91,7 +91,7 @@ def is_group_in_aad(queue_entry):
         return False
     else:
         raise Exception(
-            f"Error getting user in Azure AD: Status code {response.status_code}"
+            ("Error getting user in Azure AD: Status code %s", response.status_code)
         )
 
 
@@ -99,7 +99,7 @@ def fetch_user_aad(user_id):
     """This is an outbound request to get a single user from Azure AD."""
     headers = AUTH.check_token("GET")
     if headers:
-        url = f"{GRAPH_URL}/{GRAPH_VERSION}/users/{user_id}"
+        url = ("%s/%s/users/%s", GRAPH_URL, GRAPH_VERSION, user_id)
         response = requests.get(url=url, headers=headers)
         return response
 
@@ -107,7 +107,7 @@ def fetch_user_aad(user_id):
 def fetch_group_aad(group_id):
     headers = AUTH.check_token("GET")
     if headers:
-        url = f"{GRAPH_URL}/{GRAPH_VERSION}/groups/{group_id}"
+        url = ("%s/%s/groups/%s", GRAPH_URL, GRAPH_VERSION, group_id)
         response = requests.get(url=url, headers=headers)
         return response
 
@@ -131,7 +131,7 @@ def update_user_aad(user):
             user_id = user["user_id"]
         else:
             user_id = user["user_principal_name"]
-        url = f"{GRAPH_URL}/{GRAPH_VERSION}/users/{user_id}"
+        url = ("%s/%s/users/%s", GRAPH_URL, GRAPH_VERSION, user_id)
         aad_user = outbound_user_filter(user, "azure")
         aad_user.pop("mail", None)
         requests.patch(url=url, headers=headers, json=aad_user)
@@ -142,9 +142,9 @@ def update_group_aad(group):
     headers = AUTH.check_token("PATCH")
     if headers:
         group_id = group["role_id"]
-        url = f"{GRAPH_URL}/{GRAPH_VERSION}/groups/{group_id}"
+        url = ("%s/%s/groups/%s", GRAPH_URL, GRAPH_VERSION, group_id)
         aad_group = outbound_group_filter(group, "azure")
-        response = requests.patch(url=url, headers=headers, json=aad_group)
+        requests.patch(url=url, headers=headers, json=aad_group)
 
 
 def create_entry_aad(queue_entry):
@@ -161,7 +161,7 @@ def create_user_aad(queue_entry):
     """Creates a given user in AAD."""
     headers = AUTH.check_token("POST")
     if headers:
-        url = f"{GRAPH_URL}/{GRAPH_VERSION}/users"
+        url = ("%s/%s/users", GRAPH_URL, GRAPH_VERSION)
         try:
             aad_user = outbound_user_creation_filter(queue_entry["data"], "azure")
         except ValueError:
@@ -186,7 +186,7 @@ def create_group_aad(queue_entry):
     """Creates a given group in aad."""
     headers = AUTH.check_token("POST")
     if headers:
-        url = f"{GRAPH_URL}/{GRAPH_VERSION}/groups"
+        url = ("%s/%s/groups", GRAPH_URL, GRAPH_VERSION)
         try:
             aad_group = outbound_group_creation_filter(queue_entry["data"], "azure")
         except ValueError:

--- a/rbac/providers/ldap/delta_inbound_sync.py
+++ b/rbac/providers/ldap/delta_inbound_sync.py
@@ -34,7 +34,7 @@ LDAP_DC = os.getenv("LDAP_DC")
 LDAP_SERVER = os.getenv("LDAP_SERVER")
 LDAP_USER = os.getenv("LDAP_USER")
 LDAP_PASS = os.getenv("LDAP_PASS")
-DELTA_SYNC_INTERVAL_SECONDS = float(os.getenv("DELTA_SYNC_INTERVAL_SECONDS", "3600"))
+DELTA_SYNC_INTERVAL_SECONDS = int(os.getenv("DELTA_SYNC_INTERVAL_SECONDS", "3600"))
 
 LDAP_FILTER_USER_DELTA = "(&(objectClass=person)(whenChanged>=%s))"
 LDAP_FILTER_GROUP_DELTA = "(&(objectClass=group)(whenChanged>=%s))"

--- a/rbac/providers/ldap/initial_inbound_sync.py
+++ b/rbac/providers/ldap/initial_inbound_sync.py
@@ -97,7 +97,7 @@ def insert_to_db(data_dict, data_type):
             "timestamp": datetime.now().replace(tzinfo=timezone.utc).isoformat(),
             "provider_id": LDAP_DC,
         }
-        r.table("queue_inbound").insert(inbound_entry).run()
+        r.table("inbound_queue").insert(inbound_entry).run()
 
     LOGGER.info(
         "Inserted %s %s records into inbound_queue.", str(len(data_dict)), data_type

--- a/rbac/providers/ldap/ldap_inbound_service.py
+++ b/rbac/providers/ldap/ldap_inbound_service.py
@@ -52,8 +52,8 @@ DB_PORT = 28015
 # TODO: The db_attrs describe attributes of a queue message. Consider this while naming/relocating
 
 DB_TABLE_INBOUND_LDAP_SYNC_EVENT = "inbound_sync_event"
-DB_TABLE_QUEUE_INBOUND = "queue_inbound"
-DB_TABLE_QUEUE_OUTBOUND = "queue_outbound"
+DB_TABLE_QUEUE_INBOUND = "inbound_queue"
+DB_TABLE_QUEUE_OUTBOUND = "outbound_queue"
 DB_ATTR_LDAP_SYNC_EVENT_TIMESTAMP = "timestamp"
 DB_ATTR_DATA_TYPE = "data_type"
 DB_VALUE_DATA_TYPE_USER = "user"

--- a/rbac/providers/next/inbound_sync.py
+++ b/rbac/providers/next/inbound_sync.py
@@ -17,3 +17,60 @@
 A receiver module that pulls entries from the inbound queue table in rethinkdb
 and updates the blockchain state in rethinkdb.
 """
+
+import os
+import time
+import logging
+from rbac.providers.common.expected_errors import ExpectedError
+from rbac.providers.common.rethink_db import (
+    connect_to_db,
+    peek_at_queue,
+    put_entry_changelog,
+    delete_entry_queue,
+)
+
+DEFAULT_CONFIG = {"DELAY": 1, "INBOUND_QUEUE": "inbound_queue"}
+
+DELAY = os.environ.get("DELAY", DEFAULT_CONFIG["DELAY"])
+INBOUND_QUEUE = os.getenv("INBOUND_QUEUE", DEFAULT_CONFIG["INBOUND_QUEUE"])
+DIRECTION = "sawtooth"
+
+# LOGGER levels: info, debug, warning, exception, error
+logging.basicConfig(level=logging.INFO)
+LOGGER = logging.getLogger(__name__)
+
+
+def inbound_sync_listener():
+    """Initialize a delta inbound sync between the inbound queue and sawtooth."""
+    LOGGER.info("Starting inbound sync listener...")
+
+    LOGGER.info("Connecting to RethinkDB...")
+    connect_to_db()
+    LOGGER.info("Successfully connected to RethinkDB!")
+
+    while True:
+        try:
+            queue_entry = peek_at_queue(INBOUND_QUEUE)
+            LOGGER.info(
+                "Received queue entry %s from outbound queue...", queue_entry["id"]
+            )
+
+            data_type = queue_entry["data_type"]
+            LOGGER.info("Putting %s into Sawtooth...", data_type)
+            # TODO: Validate queue_entry.
+            # TODO: Transform or reject invalid entries.
+            # TODO: Get queue_entry object from NEXT state table.
+            # TODO: Update object or create if it doesn't exist.
+            LOGGER.debug(queue_entry)
+
+            LOGGER.info("Putting queue entry into changelog...")
+            put_entry_changelog(queue_entry, DIRECTION)
+
+            LOGGER.info("Deleting queue entry from outbound queue...")
+            entry_id = queue_entry["id"]
+            delete_entry_queue(entry_id, INBOUND_QUEUE)
+        except ExpectedError as err:
+            time.sleep(DELAY)
+        except Exception as err:
+            LOGGER.exception(err)
+            raise err


### PR DESCRIPTION
 *  Listen and pull events from the inbound queue.
 *  Bugfix in rbac-provider-ldap: returning string instead of int for getenv.
 *  Use python 3.5 image in rbac-provider-azure instead of 3.7.
 *  Bugfix in rbac-provider-azure: remove 3.6 f-strings.
 *  Bugfix multiple: name change for inbound and outbound queues.

[Task: #747]

Signed-off-by: jbobo <j.ned@bobonana.me>