### PR TITLE
Tests for 514

### DIFF
--- a/tests/unit/providers/azure_provider.py
+++ b/tests/unit/providers/azure_provider.py
@@ -20,10 +20,6 @@ import pytest
 
 from rbac.providers.azure.aad_auth import AadAuth
 from rbac.providers.azure.initial_inbound_sync import get_ids_from_list_of_dicts
-from rbac.providers.common.inbound_filters import (
-    inbound_group_filter,
-    inbound_user_filter,
-)
 from tests.unit.providers.azure_reponse_mocks import mock_requests_post
 
 # Tests are commented out until function level testing can occur.
@@ -55,36 +51,6 @@ def test_time_left_false():
     AADAUTH.token_creation_timestamp = time
     result = AADAUTH._time_left()  # pylint: disable=protected-access
     assert result is False
-
-
-def test_inbound_user_filter():
-    """Test the inbound user filter for azure transforms and returns a user dict."""
-    result = inbound_user_filter({"id": 1234}, "azure")
-    assert isinstance(result, dict) is True
-    assert result["user_id"] == 1234
-    assert "id" not in result
-    assert result["job_title"] is None
-
-
-def test_inbound_user_filter_bad_provider():
-    """Test the inbound user filter with bad provider throws error"""
-    with pytest.raises(TypeError):
-        inbound_user_filter({"id": 1234}, "potato")
-
-
-def test_inbound_group_filter():
-    """Test the inbound group filter for azure transforms and returns a group dict."""
-    result = inbound_group_filter({"id": 1234}, "azure")
-    assert isinstance(result, dict) is True
-    assert result["role_id"] == 1234
-    assert "id" not in result
-    assert result["classification"] is None
-
-
-def test_inbound_group_filter_bad_provider():
-    """Test the inbound group filter with bad provider throws error"""
-    with pytest.raises(TypeError):
-        inbound_group_filter({"id": 1234}, "potato")
 
 
 # def test_get_token_no_auth_type(caplog):

--- a/tests/unit/providers/common/inbound_filter_tests.py
+++ b/tests/unit/providers/common/inbound_filter_tests.py
@@ -1,0 +1,52 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import pytest
+
+
+from rbac.providers.common.inbound_filters import (
+    inbound_group_filter,
+    inbound_user_filter,
+)
+
+
+def test_inbound_user_filter():
+    """Test the inbound user filter for azure transforms and returns a user dict."""
+    result = inbound_user_filter({"id": 1234}, "azure")
+    assert isinstance(result, dict) is True
+    assert result["user_id"] == 1234
+    assert "id" not in result
+    assert result["job_title"] is None
+
+
+def test_inbound_user_filter_bad_provider():
+    """Test the inbound user filter with bad provider throws error"""
+    with pytest.raises(TypeError):
+        inbound_user_filter({"id": 1234}, "potato")
+
+
+def test_inbound_group_filter():
+    """Test the inbound group filter for azure transforms and returns a group dict."""
+    result = inbound_group_filter({"id": 1234}, "azure")
+    assert isinstance(result, dict) is True
+    assert result["role_id"] == 1234
+    assert "id" not in result
+    assert result["classification"] is None
+
+
+def test_inbound_group_filter_bad_provider():
+    """Test the inbound group filter with bad provider throws error"""
+    with pytest.raises(TypeError):
+        inbound_group_filter({"id": 1234}, "potato")

--- a/tests/unit/providers/common/outbound_filter_tests.py
+++ b/tests/unit/providers/common/outbound_filter_tests.py
@@ -1,0 +1,117 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import pytest
+
+from rbac.providers.common.outbound_filters import (
+    outbound_group_creation_filter,
+    outbound_group_filter,
+    outbound_user_filter,
+    outbound_user_creation_filter,
+)
+
+LIST_OF_VALID_INPUT = [
+    (
+        {
+            "account_enabled": True,
+            "name": "test_user",
+            "user_principal_name": "test_user@test_mail.com",
+        },
+        "azure",
+        "mailNickname",
+        "test_user",
+    ),
+    (
+        {"name": "test_user", "user_principal_name": "test_user@test_mail.com"},
+        "azure",
+        "accountEnabled",
+        True,
+    ),
+    (
+        {"name": "test_user", "user_principal_name": "test_user@test_mail.com"},
+        "ldap",
+        "accountEnabled",
+        True,
+    ),
+]
+
+LIST_OF_INVALID_INPUT = [
+    ({"account_enabled": True}, "azure", ValueError),
+    (
+        {"name": "test_user", "user_principal_name": "test_user@test_mail.com"},
+        "Potate",
+        TypeError,
+    ),
+]
+
+
+def test_outbound_user_filter():
+    """ Test outbound user filter with valid user """
+    result = outbound_user_filter({"user_id": 1234}, "azure")
+    assert isinstance(result, dict) is True
+    assert result["id"] == 1234
+    assert "job_title" not in result
+
+
+def test_outbound_user_filter_bad_provider():
+    """ Test outbound user filter with bad provider throws error"""
+    with pytest.raises(TypeError):
+        outbound_user_filter({"user_id": 1234}, "test_run")
+
+
+def test_outbound_group_filter():
+    """ Test outbound group filter with valid user """
+    result = outbound_group_filter({"role_id": 1234}, "ldap")
+    assert result["objectGUID"] == 1234
+    assert "id" not in result
+
+
+def test_outbound_group_filter_bad_provider():
+    """ Test outbound group filter with bad provider throws error"""
+    with pytest.raises(TypeError):
+        outbound_group_filter({"user_id": 1234}, "test_run")
+
+
+@pytest.mark.parametrize(
+    "test_input, provider, field_to_test, expected", LIST_OF_VALID_INPUT
+)
+def test_outbound_user_creation(test_input, provider, field_to_test, expected):
+    """ Test outbound user creation with valid provider and account"""
+    assert (
+        outbound_user_creation_filter(test_input, provider)[field_to_test] == expected
+    )
+
+
+@pytest.mark.parametrize("test_input, provider, errorType", LIST_OF_INVALID_INPUT)
+def test_outbound_user_creation_with_bad_input(test_input, provider, errorType):
+    """ Test outbound group creation with bad provider throws error"""
+    with pytest.raises(errorType):
+        outbound_user_creation_filter(test_input, provider)
+
+
+def test_outbound_group_creation():
+    """ Test outbound group creation with valid provider and group"""
+    user = {"group_nickname": "test_group"}
+    result = outbound_group_creation_filter(user, "azure")
+    assert result["mailEnabled"] is False
+    assert result["mailNickname"] == "test_group"
+    assert "mail" not in result
+
+
+@pytest.mark.parametrize("test_input, provider, errorType", LIST_OF_INVALID_INPUT)
+def test_outbound_group_creation_with_bad_input(test_input, provider, errorType):
+    """ Test outbound group creation without valid provider throws error"""
+    with pytest.raises(errorType):
+        outbound_group_creation_filter(test_input, provider)


### PR DESCRIPTION
 *  Listen and pull events from the enbound queue.
 *  Bugfix in rbac-provider-ldap: returning string instead of int for getenv.
 *  Use python 3.5 image in rbac-provider-azure instead of 3.7.
 *  Bugfix in rbac-provider-azure: remove 3.6 f-strings.
 *  Bugfix multiple: name change of inbound and outbound queues.

[Task: 747]

Signed-off-by: jbobo <j.ned@bobonana.me>

