### PR TITLE
Fixed LDAP sync transformations

### DIFF
--- a/rbac/providers/ldap/delta_outbound_sync.py
+++ b/rbac/providers/ldap/delta_outbound_sync.py
@@ -167,11 +167,11 @@ def modify_ad_attributes(distinguished_name, validated_entry, ldap_conn):
                 dn=distinguished_name,
                 changes={ad_attribute: [(MODIFY_REPLACE, [validated_entry["member"]])]},
             )
-        else:
+        elif ad_attribute != "distinguishedName":
             ldap_conn.modify(
                 dn=distinguished_name,
                 changes={
-                    ad_attribute: [(MODIFY_REPLACE, [validated_entry[ad_attribute][0]])]
+                    ad_attribute: [(MODIFY_REPLACE, [validated_entry[ad_attribute]])]
                 },
             )
 
@@ -180,7 +180,7 @@ def get_distinguished_name(queue_entry):
     """Returns the distinguished_name of the queue entry."""
     sawtooth_entry = queue_entry["data"]
     if "distinguished_name" in sawtooth_entry:
-        return sawtooth_entry["distinguished_name"][0]
+        return sawtooth_entry["distinguished_name"]
     raise ValidationException("Payload does not have a distinguished_name.")
 
 

--- a/rbac/providers/ldap/initial_inbound_sync.py
+++ b/rbac/providers/ldap/initial_inbound_sync.py
@@ -82,11 +82,19 @@ def fetch_ldap_data(data_type):
 def insert_to_db(data_dict, data_type):
     """Insert (Users | Groups) individually to RethinkDB from dict of data and begins delta sync timer."""
     for entry in data_dict:
-        entry_data = json.loads(entry.entry_to_json())["attributes"]
+        entry_to_insert = {}
+        entry_json = json.loads(entry.entry_to_json())
+        entry_attributes = entry_json["attributes"]
+        for attribute in entry_attributes:
+            if len(entry_attributes[attribute]) > 1:
+                entry_to_insert[attribute] = entry_attributes[attribute]
+            else:
+                entry_to_insert[attribute] = entry_attributes[attribute][0]
+
         if data_type == "user":
-            standardized_entry = inbound_user_filter(entry_data, "ldap")
+            standardized_entry = inbound_user_filter(entry_to_insert, "ldap")
         elif data_type == "group":
-            standardized_entry = inbound_group_filter(entry_data, "ldap")
+            standardized_entry = inbound_group_filter(entry_to_insert, "ldap")
         inbound_entry = {
             "data": standardized_entry,
             "data_type": data_type,


### PR DESCRIPTION
This commit resolves hyperledger#795. Data being imported into NEXT from
LDAP is being transformed so that values for user and group
objects are no longer shown as lists as this was causing
issue hyperledger#795.

Now, fields will be updating properly in the inbound and outbound
queue.

Signed-off-by: mtn217 <michael.nguyen79@t-mobile.com>