### PR TITLE
Display multiple approvers in pack view

### DIFF
--- a/client/src/containers/requester/PackApprovalList.css
+++ b/client/src/containers/requester/PackApprovalList.css
@@ -32,3 +32,7 @@ limitations under the License.
   font-size: 3em;
   margin-left: 10px;
 }
+
+#next-pack-approval-list-approvers {
+  margin-right: 20px;
+}

--- a/client/src/containers/requester/PackApprovalList.js
+++ b/client/src/containers/requester/PackApprovalList.js
@@ -134,7 +134,14 @@ class PackApprovalList extends Component {
             {role && role.name}
           </Grid.Column>
           <Grid.Column width={7}>
-            {proposal.approvers && this.renderUserInfo(proposal.approvers[0])}
+            { proposal.approvers && proposal.approvers.map(approver => (
+              <div
+                key={approver}
+                id='next-pack-approval-list-approvers'
+                className='pull-left'>
+                {this.renderUserInfo(approver)}
+              </div>
+            ))}
           </Grid.Column>
           <Grid.Column width={4}>
             {this.renderStatus(proposal.status)}


### PR DESCRIPTION
Roles view already displays multiple approvers. Add ability
for pack pending approval view to display details for
two approvers.

Signed-off-by: PGobz <p.gobin@gmail.com>