### PR TITLE
S8 [Task] Fix noisy expected API error logging

### DIFF
--- a/rbac/server/api/errors.py
+++ b/rbac/server/api/errors.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-import logging
-
 from sanic.response import json
 from sanic import Blueprint
 from sanic.exceptions import SanicException
+from sanic.exceptions import NotFound
+
+import rbac.common.logs as logging
 
 
 ERRORS_BP = Blueprint("errors")
@@ -85,8 +86,24 @@ class ApiInternalError(ApiException):
     pass
 
 
+@ERRORS_BP.exception(NotFound)
+async def handle_not_found(request, exception):
+    return json(
+        {"code": exception.status_code, "message": exception.message},
+        status=exception.status_code,
+    )
+
+
 @ERRORS_BP.exception(ApiException)
 def api_json_error(request, exception):
+    return json(
+        {"code": exception.status_code, "message": exception.message},
+        status=exception.status_code,
+    )
+
+
+@ERRORS_BP.exception(SanicException)
+async def handle_errors(request, exception):
     LOGGER.exception(exception)
     return json(
         {"code": exception.status_code, "message": exception.message},


### PR DESCRIPTION
Removes exception logs for not found and
expected API call errors

Task | Fix noisy expected API error logging
----------|----------
Task Title | Fix noisy expected API error logging
User Story | #678 
Description | Stopped sanic from throwing an entire stack trace exception log into the console when an expected API error occurs.
Business Need (the why): | Need to be able to distinguish exceptions that require attention versus exceptions that are expected to occur when tests are run that test expected error messages.
Applications or Systems impacted |
Dependencies | 
