### PR TITLE
Allow Key to accept Secp256k1PrivateKey

### DIFF
--- a/rbac/common/crypto/cipher.py
+++ b/rbac/common/crypto/cipher.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # -----------------------------------------------------------------------------
+"""Symmetric AES encryption library wrapper"""
+
 import base64
 from cryptography.fernet import Fernet
 
 
 class AES(Fernet):
+    """Symmetric AES encryption library wrapper"""
+
     def __init__(self, key):
         try:
             key = base64.urlsafe_b64encode(bytes.fromhex(key))
@@ -25,11 +29,13 @@ class AES(Fernet):
             raise ValueError("Fernet (AES) key must be 64 hex-encoded bytes.")
 
     def encrypt(self, data):
+        """Encrypt the given plaintext"""
         if isinstance(data, str):
             data = data.encode()
         return super().encrypt(data)
 
     def decrypt(self, token, ttl=None):
+        """Decrypt the given ciphertext"""
         if isinstance(token, str):
             token = token.encode()
         return super().decrypt(token=token, ttl=ttl)

--- a/rbac/common/crypto/keys.py
+++ b/rbac/common/crypto/keys.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # -----------------------------------------------------------------------------
+"""Eliptical curve library wrapper (secp256k1)"""
 
 import logging
 import re
@@ -48,9 +49,9 @@ class Key:
 
         if private_key is None and public_key is None:
             private_key = Secp256k1PrivateKey.new_random()
-        if isinstance(private_key, str):
+        if private_key and not isinstance(private_key, Secp256k1PrivateKey):
             private_key = Secp256k1PrivateKey.from_hex(private_key)
-        if isinstance(public_key, str):
+        if public_key and not isinstance(public_key, Secp256k1PublicKey):
             public_key = Secp256k1PublicKey.from_hex(public_key)
         if public_key is None and private_key is not None:
             public_key = self._context.get_public_key(private_key)

--- a/rbac/common/crypto/secrets.py
+++ b/rbac/common/crypto/secrets.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # -----------------------------------------------------------------------------
+"""Utility class for encrypting and decrypting keys using AES;
+and for generating a key for validating web authentication tokens"""
 
 import os
 import logging
@@ -47,23 +49,27 @@ def generate_random_string(length, chars=string.ascii_uppercase + string.digits)
 
 
 def generate_api_key(secret_key, user_id):
+    """Generate an API key for a user"""
     serializer = Serializer(secret_key)
     token = serializer.dumps({"id": user_id})
     return token.decode("ascii")
 
 
 def deserialize_api_key(secret_key, token):
+    """Decode the API key of a user"""
     serializer = Serializer(secret_key)
     return serializer.loads(token)
 
 
 # pylint: disable=unused-argument
 def encrypt_private_key(aes_key, user_id, private_key):
+    """Encrypt the private key of a user"""
     cipher = AES(aes_key)
     return cipher.encrypt(private_key)
 
 
 # pylint: disable=unused-argument
 def decrypt_private_key(aes_key, user_id, encrypted_private_key):
+    """Decrypt the private key of the user"""
     cipher = AES(aes_key)
     return cipher.decrypt(encrypted_private_key)

--- a/rbac/transaction_creation/common.py
+++ b/rbac/transaction_creation/common.py
@@ -24,6 +24,7 @@ from sawtooth_signing import CryptoFactory
 from sawtooth_signing.secp256k1 import Secp256k1PrivateKey
 
 from rbac.common import addresser
+from rbac.common.crypto.keys import Key  # pylint: disable=unused-import
 
 
 def wrap_payload_in_txn_batch(txn_key, payload, header, batch_key):
@@ -98,24 +99,3 @@ def make_header(inputs, outputs, payload_sha512, signer_pubkey, batcher_pubkey):
         payload_sha512=payload_sha512,
     )
     return header
-
-
-class Key(object):
-    def __init__(self, private_key, public_key=None):
-        self._private_key = private_key
-        if public_key is None:
-            self._public_key = (
-                sawtooth_signing.create_context("secp256k1")
-                .get_public_key(Secp256k1PrivateKey.from_hex(private_key))
-                .as_hex()
-            )
-        else:
-            self._public_key = public_key
-
-    @property
-    def public_key(self):
-        return self._public_key
-
-    @property
-    def private_key(self):
-        return self._private_key


### PR DESCRIPTION
Allows Key class to accept Secp256k1PrivateKey as
a constructor parameter, for compatibility with the
legacy transaction creation library.

Signed-off-by: Adam Gering <adam.gering@dev9.com>