### PR TITLE
S8 [Task] Remove blocknum range filters

### DIFF
--- a/rbac/server/api/utils.py
+++ b/rbac/server/api/utils.py
@@ -122,15 +122,7 @@ async def get_table_count(conn, table, head_block_num):
             .count()
             .run(conn)
         )
-    return (
-        await r.table(table)
-        .filter(
-            (head_block_num >= r.row["start_block_num"])
-            & (head_block_num <= r.row["end_block_num"])
-        )
-        .count()
-        .run(conn)
-    )
+    return await r.table(table).count().run(conn)
 
 
 def get_request_paging_info(request):

--- a/rbac/server/db/proposals_query.py
+++ b/rbac/server/db/proposals_query.py
@@ -25,10 +25,6 @@ async def fetch_all_proposal_resources(conn, head_block_num, start, limit):
     return (
         await r.table("proposals")
         .order_by(index="proposal_id")
-        .filter(
-            (head_block_num >= r.row["start_block_num"])
-            & (head_block_num < r.row["end_block_num"])
-        )
         .slice(start, start + limit)
         .map(
             lambda proposal: proposal.merge(
@@ -62,10 +58,6 @@ async def fetch_proposal_resource(conn, proposal_id, head_block_num):
     resource = (
         await r.table("proposals")
         .get_all(proposal_id, index="proposal_id")
-        .filter(
-            (head_block_num >= r.row["start_block_num"])
-            & (head_block_num < r.row["end_block_num"])
-        )
         .map(
             lambda proposal: proposal.merge(
                 {
@@ -104,10 +96,6 @@ def fetch_approver_ids(table, object_id, head_block_num):
     return (
         r.table(table)
         .get_all(object_id)
-        .filter(
-            lambda doc: (head_block_num >= doc["start_block_num"])
-            & (head_block_num < doc["end_block_num"])
-        )
         .pluck("identifiers", "manager")
         .coerce_to("array")
         .concat_map(lambda identifiers: identifiers)
@@ -118,10 +106,6 @@ def fetch_proposal_ids_by_target(target, head_block_num):
     return (
         r.table("proposals")
         .get_all(target, index="related_id")
-        .filter(
-            lambda doc: (head_block_num >= doc["start_block_num"])
-            & (head_block_num < doc["end_block_num"])
-        )
         .get_field("proposal_id")
         .coerce_to("array")
     )
@@ -131,10 +115,6 @@ def fetch_proposal_ids_by_opener(opener, head_block_num):
     return (
         r.table("proposals")
         .get_all(opener, index="opener")
-        .filter(
-            lambda doc: (head_block_num >= doc["start_block_num"])
-            & (head_block_num < doc["end_block_num"])
-        )
         .pluck("proposal_id", "object_id")
         .coerce_to("array")
     )

--- a/rbac/server/db/relationships_query.py
+++ b/rbac/server/db/relationships_query.py
@@ -25,11 +25,6 @@ def fetch_relationships(table, index, identifier, head_block_num):
     return (
         r.table(table)
         .get_all(identifier, index=index)
-        .filter(
-            lambda doc: (head_block_num >= doc["start_block_num"])
-            & (head_block_num < doc["end_block_num"]),
-            default=True,
-        )
         .get_field("identifiers")
         .coerce_to("array")
         .concat_map(lambda identifiers: identifiers)
@@ -39,12 +34,7 @@ def fetch_relationships(table, index, identifier, head_block_num):
 def fetch_relationships_by_id(table, identifier, key, head_block_num):
     return (
         r.table(table)
-        .filter(
-            lambda doc: doc["identifiers"].contains(identifier)
-            & (head_block_num >= doc["start_block_num"])
-            & (head_block_num < doc["end_block_num"]),
-            default=True,
-        )
+        .filter(lambda doc: doc["identifiers"].contains(identifier), default=True)
         .get_field(key)
         .distinct()
         .coerce_to("array")

--- a/rbac/server/db/roles_query.py
+++ b/rbac/server/db/roles_query.py
@@ -27,10 +27,6 @@ async def fetch_all_role_resources(conn, head_block_num, start, limit):
     resources = (
         await r.table("roles")
         .order_by(index="role_id")
-        .filter(
-            (head_block_num >= r.row["start_block_num"])
-            & (head_block_num < r.row["end_block_num"])
-        )
         .slice(start, start + limit)
         .map(
             lambda role: role.merge(
@@ -68,10 +64,6 @@ async def fetch_role_resource(conn, role_id, head_block_num):
     resource = (
         await r.table("roles")
         .get_all(role_id, index="role_id")
-        .filter(
-            (head_block_num >= r.row["start_block_num"])
-            & (head_block_num < r.row["end_block_num"])
-        )
         .merge(
             {
                 "id": r.row["role_id"],

--- a/rbac/server/db/tasks_query.py
+++ b/rbac/server/db/tasks_query.py
@@ -30,10 +30,6 @@ async def fetch_all_task_resources(conn, head_block_num, start, limit):
     resources = (
         await r.table("tasks")
         .order_by(index="task_id")
-        .filter(
-            (head_block_num >= r.row["start_block_num"])
-            & (head_block_num < r.row["end_block_num"])
-        )
         .slice(start, start + limit)
         .map(
             lambda task: task.merge(
@@ -65,10 +61,6 @@ async def fetch_task_resource(conn, task_id, head_block_num):
     resource = (
         await r.table("tasks")
         .get_all(task_id, index="task_id")
-        .filter(
-            (head_block_num >= r.row["start_block_num"])
-            & (head_block_num < r.row["end_block_num"])
-        )
         .merge(
             {
                 "id": r.row["task_id"],

--- a/rbac/server/db/users_query.py
+++ b/rbac/server/db/users_query.py
@@ -27,10 +27,6 @@ async def fetch_user_resource(conn, user_id, head_block_num):
     resource = (
         await r.table("users")
         .get_all(user_id, index="user_id")
-        .filter(
-            (head_block_num >= r.row["start_block_num"])
-            & (head_block_num < r.row["end_block_num"])
-        )
         .merge(
             {
                 "id": r.row["user_id"],
@@ -85,10 +81,6 @@ async def fetch_all_user_resources(conn, head_block_num, start, limit):
     return (
         await r.table("users")
         .order_by(index="user_id")
-        .filter(
-            (head_block_num >= r.row["start_block_num"])
-            & (head_block_num < r.row["end_block_num"])
-        )
         .slice(start, start + limit)
         .map(
             lambda user: user.merge(
@@ -145,11 +137,7 @@ async def fetch_all_user_resources(conn, head_block_num, start, limit):
 def fetch_user_ids_by_manager(manager_id, head_block_num):
     return (
         r.table("users")
-        .filter(
-            lambda user: (head_block_num >= user["start_block_num"])
-            & (head_block_num < user["end_block_num"])
-            & (manager_id == user["manager_id"])
-        )
+        .filter(lambda user: (manager_id == user["manager_id"]))
         .get_field("user_id")
         .coerce_to("array")
     )


### PR DESCRIPTION
Task | Remove blocknum range filters
----------|----------
Task Title | Remove blocknum range filters
User Story | #677 
Description | Blocknum ranges were used get the current state of a record, given the tables stored multiple versions of a record when changed. This changes the state tables to store only the current state and thus the blocknum ranges are unnecessary.
Business Need (the why): | 
Applications or Systems impacted |
Dependencies | 

This fixes bugs related to #831 