### PR TITLE
S8 [Task] Changes hash function to hash case insensitive

### DIFF
--- a/rbac/common/crypto/hash.py
+++ b/rbac/common/crypto/hash.py
@@ -26,16 +26,18 @@ PATTERN_12_BYTE_HASH = regex.compile(r"^" + PATTERN_12_HEX_BYTES + r"$")
 
 
 def unique_id():
-    """Generates a random 12-byte hexidecimal string"""
+    """Generates a random 12-byte hexadecimal string"""
     return os.urandom(12).hex()
 
 
 def hash_id(value):
-    """Returns a 12-byte hash of a given string, unless it is already a
-    12-byte hexadecimal string (e.g. as returned by the unique_id function).
+    """Returns a 12-byte hash of a given string (lowercased),
+    unless it is already a 12-byte hexadecimal string
+    (e.g. as returned by the unique_id function).
     Returns zero bytes if the value is None or falsey"""
     if not value:
         return PATTERN_ZERO_BYTE * 12
+    value = str(value).lower()
     if PATTERN_12_BYTE_HASH.match(value):
         return value
     return sha512(value.encode()).hexdigest()[:24]

--- a/tests/rbac/common/crypto/test_hash.py
+++ b/tests/rbac/common/crypto/test_hash.py
@@ -1,0 +1,66 @@
+# Copyright 2018 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+"""Test hash functions
+"""
+import pytest
+from rbac.common.crypto.hash import hash_id
+from rbac.common.crypto.hash import unique_id
+from rbac.common.crypto.hash import PATTERN_12_BYTE_HASH
+
+
+@pytest.mark.library
+def test_unique_id():
+    """Tests that unique_id generates a unique identifier and is unique
+    """
+    id1 = unique_id()
+    id2 = unique_id()
+    assert PATTERN_12_BYTE_HASH.match(id1)
+    assert PATTERN_12_BYTE_HASH.match(id2)
+    assert id1 != id2
+
+
+@pytest.mark.library
+def test_hash_id():
+    """Test that hash_id returns a 12-byte hexadecimal string
+       and that it returns the expected hash value
+    """
+    value = hash_id("aHashId")
+    assert PATTERN_12_BYTE_HASH.match(value)
+    assert value == "1351b4add8fae29a10ec26ba"
+
+
+@pytest.mark.library
+def test_hash_id_case_insensitive():
+    """Test that hash_id returns a 12-byte hexadecimal string
+       and that it returns the expected hash value
+    """
+    assert hash_id("aHashId") == hash_id("ahashid")
+
+
+@pytest.mark.library
+def test_hash_zero():
+    """Test that no value returns 12-byte of zeros hexadecimal string
+    """
+    assert hash_id(None) == "000000000000000000000000"
+    assert hash_id("") == "000000000000000000000000"
+
+
+@pytest.mark.library
+def test_hash_no_rehash():
+    """Test that the hash function won't rehash a 12-byte hex string
+    """
+    assert hash_id("3a392b49adf4b306976fb0d0") == "3a392b49adf4b306976fb0d0"
+    value = unique_id()
+    assert hash_id(value) == value


### PR DESCRIPTION
Task | Changes hash function to hash case insensitive
----------|----------
Task Title | Changes hash function to hash case insensitive
User Story | #736 
Description | All of which we are hashing (usernames, emails, guids) are case insensitive unique identifiers. Email and username especially needs to be unique on a case insensitive basis. We use the hash function to create unique identifiers, thus it needs to hash in a case insensitive manner.
Business Need (the why): | 
Applications or Systems impacted |
Dependencies | 
