### PR TITLE
Narrow try/catch on delta_sync validation error

### DIFF
--- a/rbac/common/logs/__init__.py
+++ b/rbac/common/logs/__init__.py
@@ -16,8 +16,6 @@
 
 import logging
 
-# from sanic.log import logger
-
 LIB_LEVELS = {"asyncio": logging.WARNING}
 LOGGER_FORMAT = "%(levelname)s %(asctime)s %(name)s %(module)s %(pathname)s %(message)s"
 
@@ -27,7 +25,6 @@ for lib, level in LIB_LEVELS.items():
     logging.getLogger(lib).setLevel(level)
 
 
-# pylint: disable=invalid-name, unused-argument
 def getLogger(name):
     """Return the logger
     Written to match the standard python logging.getLogger

--- a/rbac/providers/common/db_queries.py
+++ b/rbac/providers/common/db_queries.py
@@ -114,10 +114,7 @@ def peek_at_queue(table_name, provider_id=None):
         queue_entry = r.table(table_name).min("timestamp").coerce_to("object").run()
         return queue_entry
     except (r.ReqlNonExistenceError, r.ReqlOpFailedError, r.ReqlDriverError) as err:
-        raise ExpectedError(err)
-    except Exception as err:
-        LOGGER.warning(type(err).__name__)
-        raise err
+        return None
 
 
 def put_entry_changelog(queue_entry, direction):


### PR DESCRIPTION
I made these changes during yesterday's merge of ldap connection resilience, ldap paging, logger migration.

A decision was made to move ValidationExceptions beyond the validator function into getters for users/groups. Because of this, determining where a ValidationError comes from is less obvious/complicated, and the delta_outbound_sync worked around this by putting everything into a try/catch block.

This PR narrows the focus of the try/catch for ValidationException to the specific user/group functions that eventually throw it. There is no new functionality here, and this work was done while troubleshooting yesterday's pile of issues.