### PR TITLE
Changes create to new on transaction library

### DIFF
--- a/rbac/common/base/base_message.py
+++ b/rbac/common/base/base_message.py
@@ -388,11 +388,9 @@ class BaseMessage(AddressBase):
         outputs = set(list(payload.outputs))
         return message, message_type, inputs, outputs
 
-    def create(self, signer_keypair, **kwargs):
-        """Send a message to the blockchain"""
+    def new(self, signer_keypair, **kwargs):
+        """Creates and send a message to the blockchain"""
         message = kwargs.get("message")
-        object_id = kwargs.get("object_id")
-        related_id = kwargs.get("related_id")
         if not message:
             message = self.make(**kwargs)
         else:
@@ -400,11 +398,9 @@ class BaseMessage(AddressBase):
         return self.send(
             signer_keypair=signer_keypair,
             payload=self.make_payload(message=message, signer_keypair=signer_keypair),
-            object_id=object_id,
-            related_id=related_id,
         )
 
-    def send(self, signer_keypair, payload, object_id=None, related_id=None):
+    def send(self, signer_keypair, payload):
         """Sends a payload to the validator API"""
         if not isinstance(signer_keypair, Key):
             raise TypeError("Expected signer_keypair to be a Key")
@@ -414,13 +410,8 @@ class BaseMessage(AddressBase):
         _, _, batch_list, _ = batcher.make(
             payload=payload, signer_keypair=signer_keypair
         )
-        got = None
         status = client.send_batches_get_status(batch_list=batch_list)
-
-        if object_id is not None:
-            got = self.get(object_id=object_id, related_id=related_id)
-
-        return got, status
+        return status
 
     def get(self, object_id, related_id=None):
         """Gets an address from the blockchain from the validator API"""

--- a/tests/rbac/common/base/base_message.py
+++ b/tests/rbac/common/base/base_message.py
@@ -242,7 +242,7 @@ def test_create_with_kargs():
     user_key = helper.user.key()
     user_id = user_key.public_key
 
-    _, status = rbac.user.create(signer_keypair=user_key, user_id=user_id, name=name)
+    status = rbac.user.new(signer_keypair=user_key, user_id=user_id, name=name)
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
@@ -259,7 +259,7 @@ def test_create_with_message():
     user_id = user_key.public_key
     message = rbac.user.make(user_id=user_id, name=name)
 
-    _, status = rbac.user.create(signer_keypair=user_key, message=message)
+    status = rbac.user.new(signer_keypair=user_key, message=message)
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 

--- a/tests/rbac/common/role/confirm_admin_test.py
+++ b/tests/rbac/common/role/confirm_admin_test.py
@@ -84,13 +84,14 @@ def test_create():
 
     reason = helper.role.admin.propose.reason()
 
-    confirm, status = rbac.role.admin.confirm.create(
+    status = rbac.role.admin.confirm.new(
         signer_keypair=role_admin_key,
         proposal_id=proposal.proposal_id,
         role_id=proposal.object_id,
         user_id=proposal.related_id,
         reason=reason,
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 

--- a/tests/rbac/common/role/confirm_member_test.py
+++ b/tests/rbac/common/role/confirm_member_test.py
@@ -86,19 +86,22 @@ def test_create():
     proposal, _, _, role_owner_key, _, _ = helper.role.member.propose.create()
 
     reason = helper.role.member.propose.reason()
-    _, status = rbac.role.member.confirm.create(
+
+    status = rbac.role.member.confirm.new(
         signer_keypair=role_owner_key,
         proposal_id=proposal.proposal_id,
         role_id=proposal.object_id,
         user_id=proposal.related_id,
         reason=reason,
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
     confirm = rbac.role.member.confirm.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
+
     assert isinstance(confirm, protobuf.proposal_state_pb2.Proposal)
     assert confirm.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_ROLE_MEMBER
     assert confirm.proposal_id == proposal.proposal_id

--- a/tests/rbac/common/role/confirm_owner_test.py
+++ b/tests/rbac/common/role/confirm_owner_test.py
@@ -92,18 +92,21 @@ def test_create():
         user_id=proposal.related_id,
         reason=reason,
     )
-    confirm, status = rbac.role.owner.confirm.create(
+
+    status = rbac.role.owner.confirm.new(
         signer_keypair=role_owner_key,
         message=message,
         object_id=proposal.object_id,
         related_id=proposal.related_id,
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
     confirm = rbac.role.owner.confirm.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
+
     assert isinstance(confirm, protobuf.proposal_state_pb2.Proposal)
     assert confirm.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_ROLE_OWNER
     assert confirm.proposal_id == proposal.proposal_id

--- a/tests/rbac/common/role/confirm_task_test.py
+++ b/tests/rbac/common/role/confirm_task_test.py
@@ -87,18 +87,21 @@ def test_create():
         task_id=proposal.related_id,
         reason=reason,
     )
-    confirm, status = rbac.role.task.confirm.create(
+
+    status = rbac.role.task.confirm.new(
         signer_keypair=task_owner_key,
         message=message,
         object_id=proposal.object_id,
         related_id=proposal.related_id,
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
     confirm = rbac.role.task.confirm.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
+
     assert isinstance(confirm, protobuf.proposal_state_pb2.Proposal)
     assert confirm.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_ROLE_TASK
     assert confirm.proposal_id == proposal.proposal_id

--- a/tests/rbac/common/role/create_role_helper.py
+++ b/tests/rbac/common/role/create_role_helper.py
@@ -72,11 +72,14 @@ class CreateRoleTestHelper:
         message = rbac.role.make(
             role_id=role_id, name=name, owners=[user.user_id], admins=[user.user_id]
         )
-        _, status = rbac.role.create(signer_keypair=keypair, message=message)
+
+        status = rbac.role.new(signer_keypair=keypair, message=message)
+
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
         role = rbac.role.get(object_id=message.role_id)
+
         assert role.role_id == message.role_id
         assert role.name == message.name
         assert rbac.role.owner.exists(object_id=role.role_id, related_id=user.user_id)

--- a/tests/rbac/common/role/create_role_test.py
+++ b/tests/rbac/common/role/create_role_test.py
@@ -98,11 +98,13 @@ def test_create():
         role_id=role_id, name=name, owners=[user.user_id], admins=[user.user_id]
     )
 
-    _, status = rbac.role.create(signer_keypair=keypair, message=message)
+    status = rbac.role.new(signer_keypair=keypair, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
     role = rbac.role.get(object_id=role_id)
+
     assert role.role_id == message.role_id
     assert role.name == message.name
     assert rbac.role.owner.exists(object_id=role.role_id, related_id=user.user_id)

--- a/tests/rbac/common/role/imports_role_test.py
+++ b/tests/rbac/common/role/imports_role_test.py
@@ -86,7 +86,7 @@ def test_create():
     name = helper.role.name()
     role_id = helper.role.id()
 
-    _, status = rbac.role.imports.create(
+    status = rbac.role.imports.new(
         signer_keypair=keypair,
         role_id=role_id,
         name=name,

--- a/tests/rbac/common/role/propose_admin_helper.py
+++ b/tests/rbac/common/role/propose_admin_helper.py
@@ -63,14 +63,16 @@ class ProposeRoleAdminTestHelper:
             reason=reason,
             metadata=None,
         )
-        proposal, status = rbac.role.admin.propose.create(
-            signer_keypair=user_key,
-            message=message,
-            object_id=role.role_id,
-            related_id=user.user_id,
-        )
+
+        status = rbac.role.admin.propose.new(signer_keypair=user_key, message=message)
+
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
+
+        proposal = rbac.role.admin.propose.get(
+            object_id=role.role_id, related_id=user.user_id
+        )
+
         assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
         assert (
             proposal.proposal_type

--- a/tests/rbac/common/role/propose_admin_test.py
+++ b/tests/rbac/common/role/propose_admin_test.py
@@ -97,14 +97,16 @@ def test_create():
         reason=reason,
         metadata=None,
     )
-    proposal, status = rbac.role.admin.propose.create(
-        signer_keypair=signer_keypair,
-        message=message,
-        object_id=role.role_id,
-        related_id=user.user_id,
-    )
+
+    status = rbac.role.admin.propose.new(signer_keypair=signer_keypair, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
+
+    proposal = rbac.role.admin.propose.get(
+        object_id=role.role_id, related_id=user.user_id
+    )
+
     assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
     assert proposal.proposal_type, protobuf.proposal_state_pb2.Proposal.ADD_ROLE_ADMIN
     assert proposal.proposal_id == proposal_id

--- a/tests/rbac/common/role/propose_member_helper.py
+++ b/tests/rbac/common/role/propose_member_helper.py
@@ -63,14 +63,16 @@ class ProposeRoleMemberTestHelper:
             reason=reason,
             metadata=None,
         )
-        proposal, status = rbac.role.member.propose.create(
-            signer_keypair=user_key,
-            message=message,
-            object_id=role.role_id,
-            related_id=user.user_id,
-        )
+
+        status = rbac.role.member.propose.new(signer_keypair=user_key, message=message)
+
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
+
+        proposal = rbac.role.member.propose.get(
+            object_id=role.role_id, related_id=user.user_id
+        )
+
         assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
         assert (
             proposal.proposal_type

--- a/tests/rbac/common/role/propose_member_test.py
+++ b/tests/rbac/common/role/propose_member_test.py
@@ -96,14 +96,18 @@ def test_create():
         reason=reason,
         metadata=None,
     )
-    proposal, status = rbac.role.member.propose.create(
-        signer_keypair=signer_keypair,
-        message=message,
-        object_id=role.role_id,
-        related_id=user.user_id,
+
+    status = rbac.role.member.propose.new(
+        signer_keypair=signer_keypair, message=message
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
+
+    proposal = rbac.role.member.propose.get(
+        object_id=role.role_id, related_id=user.user_id
+    )
+
     assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
     assert (
         proposal.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_ROLE_MEMBER

--- a/tests/rbac/common/role/propose_owner_helper.py
+++ b/tests/rbac/common/role/propose_owner_helper.py
@@ -63,14 +63,16 @@ class ProposeRoleOwnerTestHelper:
             reason=reason,
             metadata=None,
         )
-        proposal, status = rbac.role.owner.propose.create(
-            signer_keypair=user_key,
-            message=message,
-            object_id=role.role_id,
-            related_id=user.user_id,
-        )
+
+        status = rbac.role.owner.propose.new(signer_keypair=user_key, message=message)
+
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
+
+        proposal = rbac.role.owner.propose.get(
+            object_id=role.role_id, related_id=user.user_id
+        )
+
         assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
         assert (
             proposal.proposal_type

--- a/tests/rbac/common/role/propose_owner_test.py
+++ b/tests/rbac/common/role/propose_owner_test.py
@@ -96,14 +96,16 @@ def test_create():
         reason=reason,
         metadata=None,
     )
-    proposal, status = rbac.role.owner.propose.create(
-        signer_keypair=signer_keypair,
-        message=message,
-        object_id=role.role_id,
-        related_id=user.user_id,
-    )
+
+    status = rbac.role.owner.propose.new(signer_keypair=signer_keypair, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
+
+    proposal = rbac.role.owner.propose.get(
+        object_id=role.role_id, related_id=user.user_id
+    )
+
     assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
     assert proposal.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_ROLE_OWNER
     assert proposal.proposal_id == proposal_id

--- a/tests/rbac/common/role/propose_task_helper.py
+++ b/tests/rbac/common/role/propose_task_helper.py
@@ -63,14 +63,18 @@ class ProposeRoleTaskTestHelper:
             reason=reason,
             metadata=None,
         )
-        proposal, status = rbac.role.task.propose.create(
-            signer_keypair=role_owner_key,
-            message=message,
-            object_id=role.role_id,
-            related_id=task.task_id,
+
+        status = rbac.role.task.propose.new(
+            signer_keypair=role_owner_key, message=message
         )
+
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
+
+        proposal = rbac.role.task.propose.get(
+            object_id=role.role_id, related_id=task.task_id
+        )
+
         assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
         assert (
             proposal.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_ROLE_TASK

--- a/tests/rbac/common/role/propose_task_test.py
+++ b/tests/rbac/common/role/propose_task_test.py
@@ -100,14 +100,16 @@ def test_create():
         reason=reason,
         metadata=None,
     )
-    proposal, status = rbac.role.task.propose.create(
-        signer_keypair=role_owner_key,
-        message=message,
-        object_id=role.role_id,
-        related_id=task.task_id,
-    )
+
+    status = rbac.role.task.propose.new(signer_keypair=role_owner_key, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
+
+    proposal = rbac.role.task.propose.get(
+        object_id=role.role_id, related_id=task.task_id
+    )
+
     assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
     assert proposal.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_ROLE_TASK
     assert proposal.proposal_id == proposal_id

--- a/tests/rbac/common/role/reject_admin_test.py
+++ b/tests/rbac/common/role/reject_admin_test.py
@@ -83,14 +83,16 @@ def test_create():
         user_id=proposal.related_id,
         reason=reason,
     )
-    reject, status = rbac.role.admin.reject.create(
-        signer_keypair=role_admin_key,
-        message=message,
-        object_id=proposal.object_id,
-        related_id=proposal.related_id,
-    )
+
+    status = rbac.role.admin.reject.new(signer_keypair=role_admin_key, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
+
+    reject = rbac.role.admin.propose.get(
+        object_id=proposal.object_id, related_id=proposal.related_id
+    )
+
     assert isinstance(reject, protobuf.proposal_state_pb2.Proposal)
     assert reject.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_ROLE_ADMIN
     assert reject.proposal_id == proposal.proposal_id

--- a/tests/rbac/common/role/reject_member_test.py
+++ b/tests/rbac/common/role/reject_member_test.py
@@ -85,14 +85,21 @@ def test_create():
         user_id=proposal.related_id,
         reason=reason,
     )
-    reject, status = rbac.role.member.reject.create(
+
+    status = rbac.role.member.reject.new(
         signer_keypair=role_owner_key,
         message=message,
         object_id=proposal.object_id,
         related_id=proposal.related_id,
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
+
+    reject = rbac.role.member.propose.get(
+        object_id=proposal.object_id, related_id=proposal.related_id
+    )
+
     assert isinstance(reject, protobuf.proposal_state_pb2.Proposal)
     assert reject.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_ROLE_MEMBER
     assert reject.proposal_id == proposal.proposal_id

--- a/tests/rbac/common/role/reject_owner_test.py
+++ b/tests/rbac/common/role/reject_owner_test.py
@@ -85,14 +85,16 @@ def test_create():
         user_id=proposal.related_id,
         reason=reason,
     )
-    reject, status = rbac.role.owner.reject.create(
-        signer_keypair=role_owner_key,
-        message=message,
-        object_id=proposal.object_id,
-        related_id=proposal.related_id,
-    )
+
+    status = rbac.role.owner.reject.new(signer_keypair=role_owner_key, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
+
+    reject = rbac.role.owner.propose.get(
+        object_id=proposal.object_id, related_id=proposal.related_id
+    )
+
     assert isinstance(reject, protobuf.proposal_state_pb2.Proposal)
     assert reject.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_ROLE_OWNER
     assert reject.proposal_id == proposal.proposal_id

--- a/tests/rbac/common/role/reject_task_test.py
+++ b/tests/rbac/common/role/reject_task_test.py
@@ -83,14 +83,16 @@ def test_create():
         task_id=proposal.related_id,
         reason=reason,
     )
-    reject, status = rbac.role.task.reject.create(
-        signer_keypair=task_owner_key,
-        message=message,
-        object_id=proposal.object_id,
-        related_id=proposal.related_id,
-    )
+
+    status = rbac.role.task.reject.new(signer_keypair=task_owner_key, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
+
+    reject = rbac.role.task.propose.get(
+        object_id=proposal.object_id, related_id=proposal.related_id
+    )
+
     assert isinstance(reject, protobuf.proposal_state_pb2.Proposal)
     assert reject.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_ROLE_TASK
     assert reject.proposal_id == proposal.proposal_id

--- a/tests/rbac/common/task/confirm_admin_test.py
+++ b/tests/rbac/common/task/confirm_admin_test.py
@@ -89,15 +89,16 @@ def test_create():
         user_id=proposal.related_id,
         reason=reason,
     )
-    _, status = rbac.task.admin.confirm.create(
-        signer_keypair=task_admin_key, message=message
-    )
+
+    status = rbac.task.admin.confirm.new(signer_keypair=task_admin_key, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
     confirm = rbac.task.admin.confirm.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
+
     assert isinstance(confirm, protobuf.proposal_state_pb2.Proposal)
     assert confirm.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_TASK_ADMIN
     assert confirm.proposal_id == proposal.proposal_id

--- a/tests/rbac/common/task/confirm_owner_test.py
+++ b/tests/rbac/common/task/confirm_owner_test.py
@@ -91,15 +91,16 @@ def test_create():
         user_id=proposal.related_id,
         reason=reason,
     )
-    _, status = rbac.task.owner.confirm.create(
-        signer_keypair=task_owner_key, message=message
-    )
+
+    status = rbac.task.owner.confirm.new(signer_keypair=task_owner_key, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
     confirm = rbac.task.owner.confirm.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
+
     assert isinstance(confirm, protobuf.proposal_state_pb2.Proposal)
     assert confirm.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_TASK_OWNER
     assert confirm.proposal_id == proposal.proposal_id

--- a/tests/rbac/common/task/create_task_helper.py
+++ b/tests/rbac/common/task/create_task_helper.py
@@ -72,13 +72,14 @@ class CreateTaskTestHelper:
         message = rbac.task.make(
             task_id=task_id, name=name, owners=[user.user_id], admins=[user.user_id]
         )
-        _, status = rbac.task.create(
-            signer_keypair=keypair, message=message, object_id=message.task_id
-        )
+
+        status = rbac.task.new(signer_keypair=keypair, message=message)
+
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
         task = rbac.task.get(object_id=message.task_id)
+
         assert task.task_id == message.task_id
         assert task.name == message.name
         assert rbac.task.owner.exists(object_id=task.task_id, related_id=user.user_id)

--- a/tests/rbac/common/task/create_task_test.py
+++ b/tests/rbac/common/task/create_task_test.py
@@ -97,7 +97,8 @@ def test_create():
         task_id=task_id, name=name, owners=[user.user_id], admins=[user.user_id]
     )
 
-    _, status = rbac.task.create(signer_keypair=keypair, message=message)
+    status = rbac.task.new(signer_keypair=keypair, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
@@ -123,11 +124,13 @@ def test_create_two_owners():
         admins=[user.user_id, user2.user_id],
     )
 
-    _, status = rbac.task.create(signer_keypair=keypair, message=message)
+    status = rbac.task.new(signer_keypair=keypair, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
     task = rbac.task.get(object_id=task_id)
+
     assert task.task_id == message.task_id
     assert task.name == message.name
     assert rbac.task.owner.exists(object_id=task.task_id, related_id=user.user_id)

--- a/tests/rbac/common/task/propose_admin_helper.py
+++ b/tests/rbac/common/task/propose_admin_helper.py
@@ -63,14 +63,21 @@ class ProposeTaskAdminTestHelper:
             reason=reason,
             metadata=None,
         )
-        proposal, status = rbac.task.admin.propose.create(
+
+        status = rbac.task.admin.propose.new(
             signer_keypair=user_key,
             message=message,
             object_id=task.task_id,
             related_id=user.user_id,
         )
+
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
+
+        proposal = rbac.task.admin.propose.get(
+            object_id=task.task_id, related_id=user.user_id
+        )
+
         assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
         assert (
             proposal.proposal_type

--- a/tests/rbac/common/task/propose_admin_test.py
+++ b/tests/rbac/common/task/propose_admin_test.py
@@ -94,14 +94,16 @@ def test_create():
         reason=reason,
         metadata=None,
     )
-    _, status = rbac.task.admin.propose.create(
-        signer_keypair=signer_keypair, message=message
-    )
+
+    status = rbac.task.admin.propose.new(signer_keypair=signer_keypair, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
+
     proposal = rbac.task.admin.propose.get(
         object_id=task.task_id, related_id=user.user_id
     )
+
     assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
     assert proposal.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_TASK_ADMIN
     assert proposal.proposal_id == proposal_id

--- a/tests/rbac/common/task/propose_owner_helper.py
+++ b/tests/rbac/common/task/propose_owner_helper.py
@@ -63,14 +63,21 @@ class ProposeTaskOwnerTestHelper:
             reason=reason,
             metadata=None,
         )
-        proposal, status = rbac.task.owner.propose.create(
+
+        status = rbac.task.owner.propose.new(
             signer_keypair=user_key,
             message=message,
             object_id=task.task_id,
             related_id=user.user_id,
         )
+
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
+
+        proposal = rbac.task.owner.propose.get(
+            object_id=task.task_id, related_id=user.user_id
+        )
+
         assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
         assert (
             proposal.proposal_type

--- a/tests/rbac/common/task/propose_owner_test.py
+++ b/tests/rbac/common/task/propose_owner_test.py
@@ -96,14 +96,21 @@ def test_create():
         reason=reason,
         metadata=None,
     )
-    proposal, status = rbac.task.owner.propose.create(
+
+    status = rbac.task.owner.propose.new(
         signer_keypair=signer_keypair,
         message=message,
         object_id=task.task_id,
         related_id=user.user_id,
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
+
+    proposal = rbac.task.owner.propose.get(
+        object_id=task.task_id, related_id=user.user_id
+    )
+
     assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
     assert proposal.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_TASK_OWNER
     assert proposal.proposal_id == proposal_id

--- a/tests/rbac/common/task/reject_admin_test.py
+++ b/tests/rbac/common/task/reject_admin_test.py
@@ -84,14 +84,21 @@ def test_create():
         user_id=proposal.related_id,
         reason=reason,
     )
-    reject, status = rbac.task.admin.reject.create(
+
+    status = rbac.task.admin.reject.new(
         signer_keypair=task_admin_key,
         message=message,
         object_id=proposal.object_id,
         related_id=proposal.related_id,
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
+
+    reject = rbac.task.admin.propose.get(
+        object_id=proposal.object_id, related_id=proposal.related_id
+    )
+
     assert isinstance(reject, protobuf.proposal_state_pb2.Proposal)
     assert reject.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_TASK_ADMIN
     assert reject.proposal_id == proposal.proposal_id

--- a/tests/rbac/common/task/reject_owner_test.py
+++ b/tests/rbac/common/task/reject_owner_test.py
@@ -85,14 +85,21 @@ def test_create():
         user_id=proposal.related_id,
         reason=reason,
     )
-    reject, status = rbac.task.owner.reject.create(
+
+    status = rbac.task.owner.reject.new(
         signer_keypair=task_owner_key,
         message=message,
         object_id=proposal.object_id,
         related_id=proposal.related_id,
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
+
+    reject = rbac.task.admin.propose.get(
+        object_id=proposal.object_id, related_id=proposal.related_id
+    )
+
     assert isinstance(reject, protobuf.proposal_state_pb2.Proposal)
     assert reject.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_TASK_OWNER
     assert reject.proposal_id == proposal.proposal_id

--- a/tests/rbac/common/user/confirm_manager_good_test.py
+++ b/tests/rbac/common/user/confirm_manager_good_test.py
@@ -79,21 +79,23 @@ def test_make_addresses():
 def test_create():
     """Test confirming a manager proposal"""
     proposal, _, _, _, manager_key = helper.user.manager.propose.create()
-
     reason = helper.user.manager.propose.reason()
-    _, status = rbac.user.manager.confirm.create(
+
+    status = rbac.user.manager.confirm.new(
         signer_keypair=manager_key,
         proposal_id=proposal.proposal_id,
         user_id=proposal.object_id,
         manager_id=proposal.related_id,
         reason=reason,
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
     confirm = rbac.user.manager.confirm.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
+
     assert isinstance(confirm, protobuf.proposal_state_pb2.Proposal)
     assert (
         confirm.proposal_type

--- a/tests/rbac/common/user/create_user_bad_test.py
+++ b/tests/rbac/common/user/create_user_bad_test.py
@@ -45,7 +45,7 @@ def test_make_with_self_manager():
         rbac.user.make_payload(message=message, signer_keypair=user_key)
 
     with pytest.raises(ValueError):
-        rbac.user.create(signer_keypair=user_key, message=message)
+        rbac.user.new(signer_keypair=user_key, message=message)
 
 
 @pytest.mark.user
@@ -66,7 +66,9 @@ def test_with_self_manager():
         inputs=inputs,
         outputs=outputs,
     )
-    _, status = rbac.user.send(signer_keypair=user_key, payload=payload)
+
+    status = rbac.user.send(signer_keypair=user_key, payload=payload)
+
     assert len(status) == 1
     assert status[0]["status"] == "INVALID"
 
@@ -91,7 +93,9 @@ def test_with_manager_not_in_state():
         inputs=inputs,
         outputs=outputs,
     )
-    _, status = rbac.user.send(signer_keypair=user_key, payload=payload)
+
+    status = rbac.user.send(signer_keypair=user_key, payload=payload)
+
     assert len(status) == 1
     assert status[0]["status"] == "INVALID"
 
@@ -138,6 +142,8 @@ def test_with_other_signer():
         inputs=inputs,
         outputs=outputs,
     )
-    _, status = rbac.user.send(signer_keypair=other_key, payload=payload)
+
+    status = rbac.user.send(signer_keypair=other_key, payload=payload)
+
     assert len(status) == 1
     assert status[0]["status"] == "INVALID"

--- a/tests/rbac/common/user/create_user_good_test.py
+++ b/tests/rbac/common/user/create_user_good_test.py
@@ -156,7 +156,7 @@ def test_create_user():
     user_key = helper.user.key()
     user_id = user_key.public_key
 
-    _, status = rbac.user.create(
+    status = rbac.user.new(
         signer_keypair=user_key,
         user_id=user_id,
         name=name,
@@ -164,10 +164,12 @@ def test_create_user():
         email=email,
         key=user_key.public_key,
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
     user = rbac.user.get(object_id=user_id)
+
     assert user.user_id == user_id
     assert user.name == name
     assert user.username == username
@@ -189,7 +191,7 @@ def test_create_with_manager():
     manager_name = helper.user.name()
     manager_email = helper.user.email()
 
-    _, status = rbac.user.create(
+    status = rbac.user.new(
         signer_keypair=manager_key,
         user_id=manager_id,
         name=manager_name,
@@ -197,16 +199,18 @@ def test_create_with_manager():
         email=manager_email,
         key=manager_key.public_key,
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
     manager = rbac.user.get(object_id=manager_id)
+
     assert manager.user_id == manager_id
     assert manager.username == manager_username
     assert manager.name == manager_name
     assert manager.email == manager_email
 
-    _, status = rbac.user.create(
+    status = rbac.user.new(
         signer_keypair=user_key,
         user_id=user_id,
         name=name,
@@ -215,10 +219,12 @@ def test_create_with_manager():
         manager_id=manager_id,
         key=user_key.public_key,
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
     user = rbac.user.get(object_id=user_id)
+
     assert user.user_id == user_id
     assert user.username == username
     assert user.name == name

--- a/tests/rbac/common/user/create_user_helper.py
+++ b/tests/rbac/common/user/create_user_helper.py
@@ -51,11 +51,12 @@ class CreateUserTestHelper(UserTestData):
         """Create a test user"""
         message, keypair = self.message()
 
-        user, status = rbac.user.create(
-            signer_keypair=keypair, message=message, object_id=message.user_id
-        )
+        status = rbac.user.new(signer_keypair=keypair, message=message)
+
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
+
+        user = rbac.user.get(object_id=message.user_id)
 
         assert user.user_id == message.user_id
         assert user.name == message.name
@@ -68,11 +69,13 @@ class CreateUserTestHelper(UserTestData):
         message, user_key = self.message()
         message.manager_id = manager.user_id
 
-        _, status = rbac.user.create(signer_keypair=manager_key, message=message)
+        status = rbac.user.new(signer_keypair=manager_key, message=message)
+
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
         user = rbac.user.get(object_id=message.user_id)
+
         assert user.user_id == message.user_id
         assert user.name == message.name
         assert user.manager_id == manager.user_id
@@ -85,7 +88,8 @@ class CreateUserTestHelper(UserTestData):
         message, manager_key = self.message()
         message.manager_id = grandmgr.user_id
 
-        _, status = rbac.user.create(signer_keypair=grandmgr_key, message=message)
+        status = rbac.user.new(signer_keypair=grandmgr_key, message=message)
+
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
@@ -97,11 +101,13 @@ class CreateUserTestHelper(UserTestData):
         message, user_key = self.message()
         message.manager_id = manager.user_id
 
-        _, status = rbac.user.create(signer_keypair=manager_key, message=message)
+        status = rbac.user.new(signer_keypair=manager_key, message=message)
+
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
         user = rbac.user.get(object_id=message.user_id)
+
         assert user.user_id == message.user_id
         assert user.name == message.name
         assert user.manager_id == manager.user_id

--- a/tests/rbac/common/user/imports_user_test.py
+++ b/tests/rbac/common/user/imports_user_test.py
@@ -88,13 +88,15 @@ def test_imports_user():
     name = helper.user.name()
     signer_keypair = helper.user.key()
 
-    _, status = rbac.user.imports.create(
+    status = rbac.user.imports.new(
         signer_keypair=signer_keypair, user_id=user_id, name=name
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
     user = rbac.user.get(object_id=user_id)
+
     assert user.user_id == user_id
     assert user.name == name
 
@@ -109,23 +111,27 @@ def test_create_with_manager():
     manager_id = helper.user.id()
     manager_name = helper.user.name()
 
-    _, status = rbac.user.imports.create(
+    status = rbac.user.imports.new(
         signer_keypair=signer_keypair, user_id=manager_id, name=manager_name
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
     manager = rbac.user.get(object_id=manager_id)
+
     assert manager.user_id == manager_id
     assert manager.name == manager_name
 
-    _, status = rbac.user.imports.create(
+    status = rbac.user.imports.new(
         signer_keypair=signer_keypair, user_id=user_id, name=name, manager_id=manager_id
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
     user = rbac.user.get(object_id=user_id)
+
     assert user.user_id == user_id
     assert user.name == name
     assert user.manager_id == manager_id
@@ -140,13 +146,15 @@ def test_create_with_manager_not_in_state():
     name = helper.user.name()
     manager_id = helper.user.id()
 
-    _, status = rbac.user.imports.create(
+    status = rbac.user.imports.new(
         signer_keypair=signer_keypair, user_id=user_id, name=name, manager_id=manager_id
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
     user = rbac.user.get(object_id=user_id)
+
     assert user.user_id == user_id
     assert user.name == name
     assert user.manager_id == manager_id
@@ -160,9 +168,10 @@ def test_reimport_user():
     name = helper.user.name()
     signer_keypair = helper.user.key()
 
-    _, status = rbac.user.imports.create(
+    status = rbac.user.imports.new(
         signer_keypair=signer_keypair, user_id=user_id, name=name
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
@@ -170,7 +179,7 @@ def test_reimport_user():
     assert user.user_id == user_id
     assert user.name == name
 
-    _, status = rbac.user.imports.create(
+    status = rbac.user.imports.new(
         signer_keypair=signer_keypair, user_id=user_id, name=name
     )
 

--- a/tests/rbac/common/user/propose_manager_bad_test.py
+++ b/tests/rbac/common/user/propose_manager_bad_test.py
@@ -39,9 +39,7 @@ def test_manager_not_in_state():
         reason=reason,
         metadata=None,
     )
-    _, status = rbac.user.manager.propose.create(
-        signer_keypair=user_key, message=message
-    )
+    status = rbac.user.manager.propose.new(signer_keypair=user_key, message=message)
     assert len(status) == 1
     assert status[0]["status"] == "INVALID"
 
@@ -61,9 +59,9 @@ def test_user_not_in_state():
         reason=reason,
         metadata=None,
     )
-    _, status = rbac.user.manager.propose.create(
-        signer_keypair=user_key, message=message
-    )
+
+    status = rbac.user.manager.propose.new(signer_keypair=user_key, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "INVALID"
 
@@ -82,9 +80,9 @@ def test_user_proposes_manager_change():
         reason=reason,
         metadata=None,
     )
-    _, status = rbac.user.manager.propose.create(
-        signer_keypair=user_key, message=message
-    )
+
+    status = rbac.user.manager.propose.new(signer_keypair=user_key, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
@@ -103,9 +101,9 @@ def test_another_proposes_manager_change():
         reason=reason,
         metadata=None,
     )
-    _, status = rbac.user.manager.propose.create(
-        signer_keypair=other_key, message=message
-    )
+
+    status = rbac.user.manager.propose.new(signer_keypair=other_key, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "INVALID"
 
@@ -126,9 +124,9 @@ def test_other_propose_manager_has_no_manager():
         reason=reason,
         metadata=None,
     )
-    _, status = rbac.user.manager.propose.create(
-        signer_keypair=other_key, message=message
-    )
+
+    status = rbac.user.manager.propose.new(signer_keypair=other_key, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "INVALID"
 
@@ -148,9 +146,9 @@ def test_manager_already_is_manager():
         reason=reason,
         metadata=None,
     )
-    _, status = rbac.user.manager.propose.create(
-        signer_keypair=manager_key, message=message
-    )
+
+    status = rbac.user.manager.propose.new(signer_keypair=manager_key, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "INVALID"
 
@@ -170,9 +168,9 @@ def test_proposed_manager_is_self():
         reason=reason,
         metadata=None,
     )
-    _, status = rbac.user.manager.propose.create(
-        signer_keypair=manager_key, message=message
-    )
+
+    status = rbac.user.manager.propose.new(signer_keypair=manager_key, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "INVALID"
 
@@ -191,8 +189,8 @@ def test_proposed_manager_is_already_proposed():
         reason=reason,
         metadata=None,
     )
-    _, status = rbac.user.manager.propose.create(
-        signer_keypair=manager_key, message=message
-    )
+
+    status = rbac.user.manager.propose.new(signer_keypair=manager_key, message=message)
+
     assert len(status) == 1
     assert status[0]["status"] == "INVALID"

--- a/tests/rbac/common/user/propose_manager_good_test.py
+++ b/tests/rbac/common/user/propose_manager_good_test.py
@@ -161,7 +161,8 @@ def test_user_propose_manager_has_no_manager():
     manager, _ = helper.user.create()
     proposal_id = rbac.addresser.proposal.unique_id()
     reason = helper.user.reason()
-    _, status = rbac.user.manager.propose.create(
+
+    status = rbac.user.manager.propose.new(
         signer_keypair=user_key,
         proposal_id=proposal_id,
         user_id=user.user_id,
@@ -169,11 +170,14 @@ def test_user_propose_manager_has_no_manager():
         reason=reason,
         metadata=None,
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
+
     proposal = rbac.user.manager.propose.get(
         object_id=user.user_id, related_id=manager.user_id
     )
+
     assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
     assert (
         proposal.proposal_type
@@ -195,7 +199,8 @@ def test_manager_propose_manager_has_no_manager():
     manager, manager_key = helper.user.create()
     proposal_id = rbac.addresser.proposal.unique_id()
     reason = helper.user.reason()
-    _, status = rbac.user.manager.propose.create(
+
+    status = rbac.user.manager.propose.new(
         signer_keypair=manager_key,
         proposal_id=proposal_id,
         user_id=user.user_id,
@@ -203,11 +208,14 @@ def test_manager_propose_manager_has_no_manager():
         reason=reason,
         metadata=None,
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
+
     proposal = rbac.user.manager.propose.get(
         object_id=user.user_id, related_id=manager.user_id
     )
+
     assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
     assert (
         proposal.proposal_type
@@ -229,7 +237,8 @@ def test_changing_propose_manager():
     new_manager, _ = helper.user.create()
     proposal_id = rbac.addresser.proposal.unique_id()
     reason = helper.user.reason()
-    _, status = rbac.user.manager.propose.create(
+
+    status = rbac.user.manager.propose.new(
         signer_keypair=user_key,
         proposal_id=proposal_id,
         user_id=proposal.object_id,
@@ -237,11 +246,14 @@ def test_changing_propose_manager():
         reason=reason,
         metadata=None,
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
+
     new_proposal = rbac.user.manager.propose.get(
         object_id=user.user_id, related_id=new_manager.user_id
     )
+
     assert isinstance(new_proposal, protobuf.proposal_state_pb2.Proposal)
     assert (
         new_proposal.proposal_type

--- a/tests/rbac/common/user/propose_manager_helper.py
+++ b/tests/rbac/common/user/propose_manager_helper.py
@@ -60,15 +60,16 @@ class ProposeManagerTestHelper:
             reason=reason,
             metadata=None,
         )
-        _, status = rbac.user.manager.propose.create(
-            signer_keypair=user_key, message=message
-        )
+
+        status = rbac.user.manager.propose.new(signer_keypair=user_key, message=message)
+
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
         proposal = rbac.user.manager.propose.get(
             object_id=user.user_id, related_id=manager.user_id
         )
+
         assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
         assert (
             proposal.proposal_type

--- a/tests/rbac/common/user/reject_manager_good_test.py
+++ b/tests/rbac/common/user/reject_manager_good_test.py
@@ -75,21 +75,23 @@ def test_make_addresses():
 def test_create():
     """Test rejecting a manager proposal"""
     proposal, _, _, _, manager_key = helper.user.manager.propose.create()
-
     reason = helper.user.manager.propose.reason()
-    _, status = rbac.user.manager.reject.create(
+
+    status = rbac.user.manager.reject.new(
         signer_keypair=manager_key,
         proposal_id=proposal.proposal_id,
         user_id=proposal.object_id,
         manager_id=proposal.related_id,
         reason=reason,
     )
+
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
     reject = rbac.user.manager.reject.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
+
     assert isinstance(reject, protobuf.proposal_state_pb2.Proposal)
     assert (
         reject.proposal_type == protobuf.proposal_state_pb2.Proposal.UPDATE_USER_MANAGER


### PR DESCRIPTION
Changes create to new on transaction library

Create took two optional params, object_id and related_id
and would do a create + get if they were passed. However,
having changed create to accept named key arguments, we
now need those key values for regular transaction parameters
in order to make proposal actions generic in the way the API
calls them. Thus, the new method only creates an object and
returns the status, and get should be called separately.

Changing the method name from "create" to "new" to support 
an object named create on the library, as we have user.create 
and user.import messages.

PR addresses issue #678, a dependency of #379