### PR TITLE
Demo approval by hierarchical user

### DIFF
--- a/rbac/common/role/confirm_member.py
+++ b/rbac/common/role/confirm_member.py
@@ -92,17 +92,19 @@ class ConfirmAddRoleMember(ProposalConfirm):
             store=store,
             signer=signer,
         )
-        if not addresser.role.owner.exists_in_state_inputs(
-            inputs=inputs,
-            input_state=input_state,
-            object_id=message.object_id,
-            related_id=signer,
-        ):
-            raise ValueError(
-                "Signer {} must be an owner of the role {}".format(
-                    signer, message.object_id
-                )
-            )
+        # TODO: change to verify proposal assignment and hierarchy
+
+    #          if not addresser.role.owner.exists_in_state_inputs(
+    #              inputs=inputs,
+    #            input_state=input_state,
+    #            object_id=message.object_id,
+    #            related_id=signer,
+    #        ):
+    #            raise ValueError(
+    #                "Signer {} must be an owner of the role {}".format(
+    #                    signer, message.object_id
+    #                )
+    #            )
 
     def apply_update(
         self, message, object_id, related_id, outputs, output_state, signer

--- a/rbac/common/role/reject_member.py
+++ b/rbac/common/role/reject_member.py
@@ -88,14 +88,17 @@ class RejectAddRoleMember(ProposalReject):
             store=store,
             signer=signer,
         )
-        if not addresser.role.owner.exists_in_state_inputs(
-            inputs=inputs,
-            input_state=input_state,
-            object_id=message.object_id,
-            related_id=signer,
-        ):
-            raise ValueError(
-                "Signer {} must be an owner of the role {}".format(
-                    signer, message.object_id
-                )
-            )
+        # TODO: change to verify proposal assignment and hierarchy
+
+
+#        if not addresser.role.owner.exists_in_state_inputs(
+#            inputs=inputs,
+#            input_state=input_state,
+#            object_id=message.object_id,
+#            related_id=signer,
+#        ):
+#            raise ValueError(
+#                "Signer {} must be an owner of the role {}".format(
+#                    signer, message.object_id
+#                )
+#            )

--- a/tests/blockchain/test_org_hierarchy.py
+++ b/tests/blockchain/test_org_hierarchy.py
@@ -980,17 +980,18 @@ class TestOrgHierarchy(unittest.TestCase):
                 - The txn signer is a Role owner.
         """
 
-        self.assertEqual(
-            self.client.confirm_add_role_members(
-                key=self.key1,
-                proposal_id=self.add_role_members_proposal_id,
-                role_id=self.role_id1,
-                user_id=self.key_manager.public_key,
-                reason=uuid4().hex,
-            )[0]["status"],
-            "INVALID",
-            "The txn signer for ConfirmAddRoleMember must be an owner " "of the role.",
-        )
+        # TODO: change to verify proposal assignment and hierarchy
+        #        self.assertEqual(
+        #            self.client.confirm_add_role_members(
+        #                key=self.key1,
+        #                proposal_id=self.add_role_members_proposal_id,
+        #                role_id=self.role_id1,
+        #                user_id=self.key_manager.public_key,
+        #                reason=uuid4().hex,
+        #            )[0]["status"],
+        #            "INVALID",
+        #            "The txn signer for ConfirmAddRoleMember must be an owner " "of the role.",
+        #        )
 
         self.assertEqual(
             self.client.confirm_add_role_members(
@@ -1050,17 +1051,18 @@ class TestOrgHierarchy(unittest.TestCase):
             "COMMITTED",
         )
 
-        self.assertEqual(
-            self.client.reject_add_role_members(
-                key=self.key2a,
-                proposal_id=proposal_id,
-                role_id=self.role_id1,
-                user_id=self.key1.public_key,
-                reason=uuid4().hex,
-            )[0]["status"],
-            "INVALID",
-            "The txn signer is not a Role Owner.",
-        )
+        # TODO: change to verify proposal assignment and hierarchy
+        #        self.assertEqual(
+        #            self.client.reject_add_role_members(
+        #                key=self.key2a,
+        #                proposal_id=proposal_id,
+        #                role_id=self.role_id1,
+        #                user_id=self.key1.public_key,
+        #                reason=uuid4().hex,
+        #            )[0]["status"],
+        #            "INVALID",
+        #            "The txn signer is not a Role Owner.",
+        #        )
 
         self.assertEqual(
             self.client.reject_add_role_members(


### PR DESCRIPTION
Removes role owner verification, to be replaced
by hierarchical role owner verification. This
PR allows demonstration of approval by a an
approver other than role owner; and will be followed
by a PR to update the verification to handle
approval on behalf of verification.