### PR TITLE
Temporarily remove signer validation

### DIFF
--- a/rbac/common/role/confirm_admin.py
+++ b/rbac/common/role/confirm_admin.py
@@ -86,17 +86,19 @@ class ConfirmAddRoleAdmin(ProposalConfirm):
             store=store,
             signer=signer,
         )
-        if not addresser.role.admin.exists_in_state_inputs(
-            inputs=inputs,
-            input_state=input_state,
-            object_id=message.object_id,
-            related_id=signer,
-        ):
-            raise ValueError(
-                "Signer {} must be an admin of the role {}".format(
-                    signer, message.object_id
-                )
-            )
+        # TODO: change to verify proposal assignment and hierarchy
+
+    #        if not addresser.role.admin.exists_in_state_inputs(
+    #            inputs=inputs,
+    #            input_state=input_state,
+    #            object_id=message.object_id,
+    #            related_id=signer,
+    #        ):
+    #            raise ValueError(
+    #                "Signer {} must be an admin of the role {}".format(
+    #                    signer, message.object_id
+    #                )
+    #            )
 
     def apply_update(
         self, message, object_id, related_id, outputs, output_state, signer

--- a/rbac/common/role/confirm_owner.py
+++ b/rbac/common/role/confirm_owner.py
@@ -92,18 +92,20 @@ class ConfirmAddRoleOwner(ProposalConfirm):
             store=store,
             signer=signer,
         )
+        # TODO: change to verify proposal assignment and hierarchy
         # TODO: should be owners?
-        if not addresser.role.admin.exists_in_state_inputs(
-            inputs=inputs,
-            input_state=input_state,
-            object_id=message.object_id,
-            related_id=signer,
-        ):
-            raise ValueError(
-                "Signer {} must be an admin of the role {}\n{}".format(
-                    signer, message.object_id, input_state
-                )
-            )
+
+    #        if not addresser.role.admin.exists_in_state_inputs(
+    #            inputs=inputs,
+    #            input_state=input_state,
+    #            object_id=message.object_id,
+    #            related_id=signer,
+    #        ):
+    #            raise ValueError(
+    #                "Signer {} must be an admin of the role {}\n{}".format(
+    #                    signer, message.object_id, input_state
+    #                )
+    #            )
 
     def apply_update(
         self, message, object_id, related_id, outputs, output_state, signer

--- a/rbac/common/role/confirm_task.py
+++ b/rbac/common/role/confirm_task.py
@@ -83,17 +83,19 @@ class ConfirmAddRoleTask(ProposalConfirm):
             store=store,
             signer=signer,
         )
-        if not addresser.task.owner.exists_in_state_inputs(
-            inputs=inputs,
-            input_state=input_state,
-            object_id=message.related_id,
-            related_id=signer,
-        ):
-            raise ValueError(
-                "Signer {} must be an owner of the task {}".format(
-                    signer, message.object_id
-                )
-            )
+        # TODO: change to verify proposal assignment and hierarchy
+
+    #        if not addresser.task.owner.exists_in_state_inputs(
+    #            inputs=inputs,
+    #            input_state=input_state,
+    #            object_id=message.related_id,
+    #            related_id=signer,
+    #        ):
+    #            raise ValueError(
+    #                "Signer {} must be an owner of the task {}".format(
+    #                    signer, message.object_id
+    #                )
+    #            )
 
     def apply_update(
         self, message, object_id, related_id, outputs, output_state, signer

--- a/rbac/common/role/reject_admin.py
+++ b/rbac/common/role/reject_admin.py
@@ -82,14 +82,17 @@ class RejectAddRoleAdmin(ProposalReject):
             store=store,
             signer=signer,
         )
-        if not addresser.role.admin.exists_in_state_inputs(
-            inputs=inputs,
-            input_state=input_state,
-            object_id=message.object_id,
-            related_id=signer,
-        ):
-            raise ValueError(
-                "Signer {} must be an admin of the role {}".format(
-                    signer, message.object_id
-                )
-            )
+        # TODO: change to verify proposal assignment and hierarchy
+
+
+#        if not addresser.role.admin.exists_in_state_inputs(
+#            inputs=inputs,
+#            input_state=input_state,
+#            object_id=message.object_id,
+#            related_id=signer,
+#        ):
+#            raise ValueError(
+#                "Signer {} must be an admin of the role {}".format(
+#                    signer, message.object_id
+#                )
+#            )

--- a/rbac/common/role/reject_owner.py
+++ b/rbac/common/role/reject_owner.py
@@ -88,15 +88,18 @@ class RejectAddRoleOwner(ProposalReject):
             store=store,
             signer=signer,
         )
+        # TODO: change to verify proposal assignment and hierarchy
         # TODO: should be owners
-        if not addresser.role.admin.exists_in_state_inputs(
-            inputs=inputs,
-            input_state=input_state,
-            object_id=message.object_id,
-            related_id=signer,
-        ):
-            raise ValueError(
-                "Signer {} must be an admin of the role {}".format(
-                    signer, message.object_id
-                )
-            )
+
+
+#        if not addresser.role.admin.exists_in_state_inputs(
+#            inputs=inputs,
+#            input_state=input_state,
+#            object_id=message.object_id,
+#            related_id=signer,
+#        ):
+#            raise ValueError(
+#                "Signer {} must be an admin of the role {}".format(
+#                    signer, message.object_id
+#                )
+#            )

--- a/rbac/common/role/reject_task.py
+++ b/rbac/common/role/reject_task.py
@@ -82,14 +82,17 @@ class RejectAddRoleTask(ProposalReject):
             store=store,
             signer=signer,
         )
-        if not addresser.task.owner.exists_in_state_inputs(
-            inputs=inputs,
-            input_state=input_state,
-            object_id=message.related_id,
-            related_id=signer,
-        ):
-            raise ValueError(
-                "Signer {} must be an owner of the task {}".format(
-                    signer, message.object_id
-                )
-            )
+        # TODO: change to verify proposal assignment and hierarchy
+
+
+#        if not addresser.task.owner.exists_in_state_inputs(
+#            inputs=inputs,
+#            input_state=input_state,
+#            object_id=message.related_id,
+#            related_id=signer,
+#        ):
+#            raise ValueError(
+#                "Signer {} must be an owner of the task {}".format(
+#                    signer, message.object_id
+#                )
+#            )

--- a/rbac/common/task/confirm_admin.py
+++ b/rbac/common/task/confirm_admin.py
@@ -86,17 +86,19 @@ class ConfirmAddTaskAdmin(ProposalConfirm):
             store=store,
             signer=signer,
         )
-        if not addresser.task.admin.exists_in_state_inputs(
-            inputs=inputs,
-            input_state=input_state,
-            object_id=message.object_id,
-            related_id=signer,
-        ):
-            raise ValueError(
-                "Signer {} must be an admin of the task {}".format(
-                    signer, message.object_id
-                )
-            )
+        # TODO: change to verify proposal assignment and hierarchy
+
+    #        if not addresser.task.admin.exists_in_state_inputs(
+    #            inputs=inputs,
+    #            input_state=input_state,
+    #            object_id=message.object_id,
+    #            related_id=signer,
+    #        ):
+    #            raise ValueError(
+    #                "Signer {} must be an admin of the task {}".format(
+    #                    signer, message.object_id
+    #                )
+    #            )
 
     def apply_update(
         self, message, object_id, related_id, outputs, output_state, signer

--- a/rbac/common/task/confirm_owner.py
+++ b/rbac/common/task/confirm_owner.py
@@ -92,22 +92,24 @@ class ConfirmAddTaskOwner(ProposalConfirm):
             store=store,
             signer=signer,
         )
-        if not addresser.task.owner.exists_in_state_inputs(
-            inputs=inputs,
-            input_state=input_state,
-            object_id=message.object_id,
-            related_id=signer,
-        ) and not addresser.task.admin.exists_in_state_inputs(
-            inputs=inputs,
-            input_state=input_state,
-            object_id=message.object_id,
-            related_id=signer,
-        ):
-            raise ValueError(
-                "Signer {} must be an owner or admin of the task {}".format(
-                    signer, message.object_id
-                )
-            )
+        # TODO: change to verify proposal assignment and hierarchy
+
+    #        if not addresser.task.owner.exists_in_state_inputs(
+    #            inputs=inputs,
+    #            input_state=input_state,
+    #            object_id=message.object_id,
+    #            related_id=signer,
+    #        ) and not addresser.task.admin.exists_in_state_inputs(
+    #            inputs=inputs,
+    #            input_state=input_state,
+    #            object_id=message.object_id,
+    #            related_id=signer,
+    #        ):
+    #            raise ValueError(
+    #                "Signer {} must be an owner or admin of the task {}".format(
+    #                    signer, message.object_id
+    #                )
+    #            )
 
     def apply_update(
         self, message, object_id, related_id, outputs, output_state, signer

--- a/rbac/common/task/reject_admin.py
+++ b/rbac/common/task/reject_admin.py
@@ -77,14 +77,17 @@ class RejectAddTaskAdmin(ProposalReject):
             store=store,
             signer=signer,
         )
-        if not addresser.task.admin.exists_in_state_inputs(
-            inputs=inputs,
-            input_state=input_state,
-            object_id=message.object_id,
-            related_id=signer,
-        ):
-            raise ValueError(
-                "Signer {} must be an admin of the task {}".format(
-                    signer, message.object_id
-                )
-            )
+        # TODO: change to verify proposal assignment and hierarchy
+
+
+#        if not addresser.task.admin.exists_in_state_inputs(
+#            inputs=inputs,
+#            input_state=input_state,
+#            object_id=message.object_id,
+#            related_id=signer,
+#        ):
+#            raise ValueError(
+#                "Signer {} must be an admin of the task {}".format(
+#                    signer, message.object_id
+#                )
+#            )

--- a/rbac/common/task/reject_owner.py
+++ b/rbac/common/task/reject_owner.py
@@ -83,19 +83,22 @@ class RejectAddTaskOwner(ProposalReject):
             store=store,
             signer=signer,
         )
-        if not addresser.task.owner.exists_in_state_inputs(
-            inputs=inputs,
-            input_state=input_state,
-            object_id=message.object_id,
-            related_id=signer,
-        ) and not addresser.task.admin.exists_in_state_inputs(
-            inputs=inputs,
-            input_state=input_state,
-            object_id=message.object_id,
-            related_id=signer,
-        ):
-            raise ValueError(
-                "Signer {} must be an owner or admin of the task {}".format(
-                    signer, message.object_id
-                )
-            )
+        # TODO: change to verify proposal assignment and hierarchy
+
+
+#        if not addresser.task.owner.exists_in_state_inputs(
+#            inputs=inputs,
+#            input_state=input_state,
+#            object_id=message.object_id,
+#            related_id=signer,
+#        ) and not addresser.task.admin.exists_in_state_inputs(
+#            inputs=inputs,
+#            input_state=input_state,
+#            object_id=message.object_id,
+#            related_id=signer,
+#        ):
+#            raise ValueError(
+#                "Signer {} must be an owner or admin of the task {}".format(
+#                    signer, message.object_id
+#                )
+#            )

--- a/rbac/common/user/confirm_manager.py
+++ b/rbac/common/user/confirm_manager.py
@@ -86,12 +86,14 @@ class ConfirmUpdateUserManager(ProposalConfirm):
         user = addresser.user.get_from_input_state(
             inputs=inputs, input_state=input_state, object_id=message.object_id
         )
-        if message.related_id != signer:
-            raise ValueError(
-                "Proposed manager {} is not the transaction signer".format(
-                    message.related_id
-                )
-            )
+        # TODO: change to verify proposal assignment and hierarchy
+
+    #        if message.related_id != signer:
+    #            raise ValueError(
+    #                "Proposed manager {} is not the transaction signer".format(
+    #                    message.related_id
+    #                )
+    #            )
 
     def store_message(
         self, object_id, related_id, store, message, outputs, output_state, signer

--- a/rbac/common/user/reject_manager.py
+++ b/rbac/common/user/reject_manager.py
@@ -77,9 +77,12 @@ class RejectUpdateUserManager(ProposalReject):
             store=store,
             signer=signer,
         )
-        if message.related_id != signer:
-            raise ValueError(
-                "Proposed manager {} is not the transaction signer {}".format(
-                    message.related_id, signer
-                )
-            )
+        # TODO: change to verify proposal assignment and hierarchy
+
+
+#        if message.related_id != signer:
+#            raise ValueError(
+#                "Proposed manager {} is not the transaction signer {}".format(
+#                    message.related_id, signer
+#                )
+#            )

--- a/tests/blockchain/test_org_hierarchy.py
+++ b/tests/blockchain/test_org_hierarchy.py
@@ -555,18 +555,18 @@ class TestOrgHierarchy(unittest.TestCase):
                 - The txn signer is a Role Admin for the role.
                 - The proposal exists and is open.
         """
-
-        self.assertEqual(
-            self.client.confirm_add_role_admins(
-                key=self.key3b,
-                proposal_id=self.add_role_admins_proposal_id,
-                role_id=self.role_id1,
-                user_id=self.key3a.public_key,
-                reason=uuid4().hex,
-            )[0]["status"],
-            "INVALID",
-            "The txn signer for ConfirmAddRoleAdmin must be an admin " "of the role.",
-        )
+        # TODO: change to verify proposal assignment and hierarchy
+        #        self.assertEqual(
+        #            self.client.confirm_add_role_admins(
+        #                key=self.key3b,
+        #                proposal_id=self.add_role_admins_proposal_id,
+        #                role_id=self.role_id1,
+        #                user_id=self.key3a.public_key,
+        #                reason=uuid4().hex,
+        #            )[0]["status"],
+        #            "INVALID",
+        #            "The txn signer for ConfirmAddRoleAdmin must be an admin " "of the role.",
+        #        )
 
         self.assertEqual(
             self.client.confirm_add_role_admins(
@@ -626,17 +626,18 @@ class TestOrgHierarchy(unittest.TestCase):
             "COMMITTED",
         )
 
-        self.assertEqual(
-            self.client.reject_add_role_admins(
-                key=self.key3b,
-                proposal_id=proposal_id,
-                role_id=self.role_id1,
-                user_id=self.key3b.public_key,
-                reason=uuid4().hex,
-            )[0]["status"],
-            "INVALID",
-            "The user is not a Role Admin.",
-        )
+        # TODO: change to verify proposal assignment and hierarchy
+        #        self.assertEqual(
+        #            self.client.reject_add_role_admins(
+        #                key=self.key3b,
+        #                proposal_id=proposal_id,
+        #                role_id=self.role_id1,
+        #                user_id=self.key3b.public_key,
+        #                reason=uuid4().hex,
+        #            )[0]["status"],
+        #            "INVALID",
+        #            "The user is not a Role Admin.",
+        #        )
 
         self.assertEqual(
             self.client.reject_add_role_admins(
@@ -838,17 +839,18 @@ class TestOrgHierarchy(unittest.TestCase):
             "COMMITTED",
         )
 
-        self.assertEqual(
-            self.client.reject_add_role_owners(
-                key=self.key3b,
-                proposal_id=proposal_id,
-                role_id=self.role_id1,
-                user_id=self.key1.public_key,
-                reason=uuid4().hex,
-            )[0]["status"],
-            "INVALID",
-            "The txn signer is not a Role Admin.",
-        )
+        # TODO: change to verify proposal assignment and hierarchy
+        #        self.assertEqual(
+        #            self.client.reject_add_role_owners(
+        #                key=self.key3b,
+        #                proposal_id=proposal_id,
+        #                role_id=self.role_id1,
+        #                user_id=self.key1.public_key,
+        #                reason=uuid4().hex,
+        #            )[0]["status"],
+        #            "INVALID",
+        #            "The txn signer is not a Role Admin.",
+        #        )
 
         self.assertEqual(
             self.client.reject_add_role_owners(
@@ -1259,17 +1261,18 @@ class TestOrgHierarchy(unittest.TestCase):
             "The proposal must exist.",
         )
 
-        self.assertEqual(
-            self.client.confirm_add_role_tasks(
-                key=self.key1,
-                proposal_id=self.add_role_tasks_proposal_id,
-                role_id=self.role_id1,
-                task_id=self.task_id1,
-                reason=uuid4().hex,
-            )[0]["status"],
-            "INVALID",
-            "The txn signer must be a Task Owner.",
-        )
+        # TODO: change to verify proposal assignment and hierarchy
+        #        self.assertEqual(
+        #            self.client.confirm_add_role_tasks(
+        #                key=self.key1,
+        #                proposal_id=self.add_role_tasks_proposal_id,
+        #                role_id=self.role_id1,
+        #                task_id=self.task_id1,
+        #                reason=uuid4().hex,
+        #            )[0]["status"],
+        #            "INVALID",
+        #            "The txn signer must be a Task Owner.",
+        #        )
 
         self.assertEqual(
             self.client.confirm_add_role_tasks(
@@ -1343,17 +1346,18 @@ class TestOrgHierarchy(unittest.TestCase):
             "The proposal must exist.",
         )
 
-        self.assertEqual(
-            self.client.reject_add_role_tasks(
-                key=self.key2a,
-                proposal_id=proposal_id,
-                role_id=self.role_id1,
-                task_id=task_id,
-                reason=uuid4().hex,
-            )[0]["status"],
-            "INVALID",
-            "The txn signer must be a Task Owner.",
-        )
+        # TODO: change to verify proposal assignment and hierarchy
+        #        self.assertEqual(
+        #            self.client.reject_add_role_tasks(
+        #                key=self.key2a,
+        #                proposal_id=proposal_id,
+        #                role_id=self.role_id1,
+        #                task_id=task_id,
+        #                reason=uuid4().hex,
+        #            )[0]["status"],
+        #            "INVALID",
+        #            "The txn signer must be a Task Owner.",
+        #        )
 
         self.assertEqual(
             self.client.reject_add_role_tasks(


### PR DESCRIPTION
We are changing signer validation to verify key records
instead of forcing user_id to be the public_key. This
facilitates imported users from performing actions,
and will allow for key revocation.

Signed-off-by: Adam Gering <adam.gering@dev9.com>