### PR TITLE
Makes CORS permissive

### DIFF
--- a/rbac/server/api/main.py
+++ b/rbac/server/api/main.py
@@ -114,12 +114,7 @@ def main():
         app,
         automatic_options=True,
         supports_credentials=True,
-        resources={
-            r"/api/*": {
-                "origins": app.config.CLIENT_HOST + ":" + app.config.CLIENT_PORT
-            },
-            r"/webhooks/*": {"origins": "*"},
-        },
+        resources={r"/api/*": {"origins": "*"}, r"/webhooks/*": {"origins": "*"}},
     )
 
     zmq = ZMQEventLoop()


### PR DESCRIPTION
Permissive CORS is preferred for development
purposes. Production API configurations will
be added later.
