### PR TITLE
Fix required node_path environment default

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -155,6 +155,7 @@ services:
     container_name: rbac-client
     environment:
       - CHOKIDAR_USEPOLLING=true
+      - NODE_PATH=${NODE_PATH-src/}
       - REACT_APP_SERVER_HOST=${REACT_APP_SERVER_HOST}
       - REACT_APP_SERVER_PORT=${REACT_APP_SERVER_PORT}
       - REACT_APP_HTTP_PROTOCOL=${REACT_APP_HTTP_PROTOCOL}


### PR DESCRIPTION
Client does not build pulling down master branch and starting; without this required NODE_PATH environment variable default set.
