### PR TITLE
Implemented Nginx Reverse Proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,9 @@ secrets.sh
 # temporary files
 *.tmp
 *.log*
+
+# Certs folder
+/certs
+
+# Nginx Config file
+nginx.conf

--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ bin/stop
 By default, the data in the development environment is ephemeral.
 It will be lost when the application is stopped and restarted.
 
-To enable persistent data, use the -p flag:
+To enable persistent data, use the -c flag:
 
 ```bash
-bin/start -p
+bin/start -c
 ```
 
 To delete the persistent data, delete the related docker volumes:
@@ -185,6 +185,13 @@ Once that work is complete, the random key generation can be removed as well.
 In other words: It must be made obvious to a user when startup fails due to 
 missing keys.
 
+#### Configure SSL/TLS on NEXT
+
+To configure SSL/TLS on NEXT, visit our Sphinx Docs and navigate to the Configure SSL/TLS page.
+
+After following those steps, run the following command to run the containers with SSL/TLS enabled:
+
+```./bin/start -b -p```
 
 ## Testing
 

--- a/bin/start
+++ b/bin/start
@@ -28,8 +28,9 @@ usage() {
 
         Options:
                                start from genesis (no data) [default]
-            -p --persist       start with persistent data
+            -c --persist       start with persistent data
             -b --build         (re)build docker images before starting
+            -p --prod          start NEXT with SSL configuration
 
 EOM
 
@@ -50,8 +51,9 @@ while [[ $# -gt 0 ]]; do
     case "$opt" in
     "-h"|"--help"       ) usage; exit 0;;
     "-b"|"--build"      ) BUILD=1;;
-    "-p"|"--persist"    ) PERSIST=1;;
+    "-c"|"--persist"    ) PERSIST=1;;
     "-d"|"--dev"        ) DEV=1;;
+    "-p"|"--prod"       ) PROD=1;;
     *                   ) echo "ERROR: Invalid option: \""$opt"\"" >&2
                             usage
                             exit 1;;
@@ -63,6 +65,16 @@ CMD="docker-compose -f docker-compose.yaml"
 
 if [[ "$PERSIST" == "1" ]]; then
     CMD="$CMD -f docker-persist.yaml"
+fi
+if [[ "$PROD" == "1" ]]; then
+    CMD="$CMD -f docker-compose.prod.yaml"
+    if ! [ -e nginx.conf ] 
+    then
+        echo "nginx.conf file not found. Creating one from nginx.conf-example ..."
+        cp ./nginx.conf-example ./nginx.conf
+    fi
+else
+    CMD="$CMD -f docker-compose.override.yaml"
 fi
 CMD="$CMD up"
 if [[ "$BUILD" == "1" ]]; then

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,0 +1,33 @@
+# Copyright 2019 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# This docker-compose.yaml file will be used to deploy to a development environment.
+# This file will be referenced when executing command: ./bin/start
+
+version: "3"
+
+services:
+  rbac-server:
+    ports:
+      - "8000:8000"
+
+  client:
+    ports:
+      - "4201:3000"
+      - "35729:35729"
+
+  chatbot:
+    ports:
+      - "5005:5005"

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,0 +1,46 @@
+# Copyright 2019 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# This docker-compose.yaml file will be used to deploy to a production environment.
+# This file will be referenced when executing command: ./bin/start -p
+
+version: "3"
+
+services:
+  rbac-server:
+    expose:
+      - "8000"
+
+  client:
+    expose:
+      - "3000"
+
+  chatbot:
+    expose:
+      - "5005"
+
+  https-proxy: 
+    image: nginx:stable-alpine
+    container_name: https-proxy
+    volumes:
+      - "./nginx.conf:/etc/nginx/nginx.conf"
+      - "./certs:/etc/nginx/certs"
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8000:8000"
+    depends_on:
+      - client
+      - rbac-server

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -91,8 +91,6 @@ services:
     image: rbac-server:${ISOLATION_ID-latest}
     volumes:
       - ".:/project/hyperledger-rbac"
-    ports:
-      - "8000:8000"
     depends_on:
       - ledger-sync
       - rethink
@@ -151,7 +149,6 @@ services:
         ./bin/setup_db --host rethink &&
         ./bin/rbac-ledger-sync --db-host rethink --validator tcp://validator:4004
       \"\""
-
   client:
     build:
       context: .
@@ -169,9 +166,6 @@ services:
     volumes:
       - ./client:/client
       - /client/node_modules
-    ports:
-      - "4201:3000"
-      - "35729:35729"
     depends_on:
       - rbac-server
 
@@ -183,8 +177,6 @@ services:
     image: rbac-chatbot:${ISOLATION_ID-latest}
     volumes:
       - ".:/project/hyperledger-rbac"
-    ports:
-      - "5005:5005"
 
   rest-api:
     container_name: sawtooth-rest-api

--- a/docker-persist.yaml
+++ b/docker-persist.yaml
@@ -16,12 +16,12 @@
 # Persistent data configuration
 #
 # Start with persistent data:
-#    bin/start -p
+#    bin/start -c
 #       -or-
 #    docker-compose -f docker-compose.yaml -f docker-persist.yaml up
 #
 # Start in development config with persistent data:
-#    bin/start -p -d
+#    bin/start -c -d
 #       -or-
 #    docker-compose -f docker-compose.yaml -f docker-persist.yaml -f docker-dev.yaml up
 #

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,4 +14,4 @@
       * Azure Active Directory Provider <azure-active-directory-provider>
    support
    developer-setup
-
+   ssl-setup

--- a/docs/ssl-setup.rst
+++ b/docs/ssl-setup.rst
@@ -1,0 +1,20 @@
+=================
+Configure SSL/TLS
+=================
+
+To run the NEXT Identity Platform with SSL/TLS enabled:
+
+1. Copy the .crt and the .key files for your domain and save them in the certs folder. Make sure the names of the .crt and the .pem files have the name of the domain. If you have the domain of example.com, the names of your two files would be example.com.crt and example.com.key
+2. Make a copy of the nginx.conf-example file in the root directory and name it nginx.conf. This will be the configuration file for the Nginx Reverse Proxy.
+3. In the nginx.conf file, replace "localhost" with your domain name (localhost should be replaced around 7 times).
+4. In the .env file, change the following environment variables to these new values:
+
+        ``CLIENT_H0ST=https://<YOUR_DOMAIN_NAME>``
+
+        ``REACT_APP_HTTP_PROTOCOL=https://``
+
+        ``REACT_APP_WS_PROTOCOL=wss://``
+
+5. Execute the ./bin/start command with the prod flag passed in to spin up your instance. SSL/TLS should be enabled.
+            ``./bin/start -b -p``
+6. NEXT is now available at at https://<YOUR_DOMAIN_NAME>.

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,52 @@
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+
+http {
+    access_log  /dev/null;
+    error_log /dev/null;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+    server {
+        listen 80 default_server;
+        server_name localhost;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443;
+        ssl on;
+        ssl_certificate /etc/nginx/certs/localhost.crt;
+        ssl_certificate_key /etc/nginx/certs/localhost.key;
+        server_name localhost;
+        location / {
+            proxy_pass http://rbac-client:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+        }
+    }
+
+    server {
+        listen 8000;
+        ssl on;
+        server_name localhost;
+        ssl_certificate /etc/nginx/certs/localhost.crt;
+        ssl_certificate_key /etc/nginx/certs/localhost.key;
+        error_page 497 https://$server_name:$server_port$request_uri;
+        location / {
+            proxy_pass http://rbac-server:8000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+        }
+    }
+}

--- a/nginx.conf-example
+++ b/nginx.conf-example
@@ -1,0 +1,70 @@
+# Copyright 2019 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    # To enable Nginx Proxy logging, delete the following two lines.
+    access_log off;
+    error_log /dev/null;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+    server {
+        listen 80 default_server;
+        server_name localhost;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443;
+        ssl on;
+        ssl_certificate /etc/nginx/certs/localhost.crt;
+        ssl_certificate_key /etc/nginx/certs/localhost.key;
+        server_name localhost;
+        location / {
+            proxy_pass http://rbac-client:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+        }
+    }
+
+    server {
+        listen 8000;
+        ssl on;
+        server_name localhost;
+        ssl_certificate /etc/nginx/certs/localhost.crt;
+        ssl_certificate_key /etc/nginx/certs/localhost.key;
+        error_page 497 https://$server_name:$server_port$request_uri;
+        location / {
+            proxy_pass http://rbac-server:8000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_read_timeout 86400;
+        }
+    }
+}


### PR DESCRIPTION
With this commit, developers can now spin up an instance of NEXT with SSL/TLS
enabled. Instructions to configure SSL/TLS has also been included in this commit.

Modifications to docker-compose.yaml were made because we will be needing
different types of docker-compose.yaml files based on what environment we are
deploying to. To enable SSL/TLS, the developer will need to run:
./bin/start -b --prod

NEXT with SSL/TLS enabled will be available at https://<domain_name>

Signed-off-by: mtn217 <michael.nguyen79@t-mobile.com>