### PR TITLE
Fixed Active Directory auth issue

### DIFF
--- a/rbac/server/api/auth.py
+++ b/rbac/server/api/auth.py
@@ -127,9 +127,10 @@ async def authorize(request):
     if auth_source == "ldap":
         if LDAP_SERVER:
             if username != "" and password != "":
+                ldap_user_dn = await auth_query.fetch_dn_by_username(request)
                 server = Server(LDAP_SERVER)
                 conn = Connection(
-                    server, user=username, password=password, read_only=True
+                    server, user=ldap_user_dn, password=password, read_only=True
                 )
 
                 if not conn.bind():
@@ -160,5 +161,5 @@ async def authorize(request):
                     },
                 )
             raise ApiBadRequest(LDAP_ERR_MESSAGES["default"])
-        raise ApiBadRequest("Missing LDAP server information.")
+        raise ApiBadRequest("Missing LDAP_SERVER env variable.")
     raise ApiBadRequest("Invalid authentication source.")

--- a/rbac/server/db/auth_query.py
+++ b/rbac/server/db/auth_query.py
@@ -94,3 +94,32 @@ async def fetch_info_by_username(request):
     conn.close()
 
     return auth_entry
+
+
+async def fetch_dn_by_username(request):
+    """Given a login request, return the user's AD Distinguished Name.
+
+    Args:
+        request (dict): The login request containing an id, password, and
+                        app configurations.
+
+    """
+    username = request.json.get("id")
+    conn = await db_utils.create_connection(
+        request.app.config.DB_HOST,
+        request.app.config.DB_PORT,
+        request.app.config.DB_NAME,
+    )
+    result = (
+        await r.table("users")
+        .filter(lambda doc: (doc["username"].match("(?i)" + username)))
+        .limit(1)
+        .coerce_to("array")
+        .run(conn)
+    )
+    if not result:
+        raise ApiNotFound("The username you entered is incorrect.")
+    result = result[0]
+    user_dn = result.get("user_id")
+    conn.close()
+    return user_dn

--- a/rbac/server/swagger/swagger/definitions/definitions.yaml
+++ b/rbac/server/swagger/swagger/definitions/definitions.yaml
@@ -693,6 +693,10 @@
         type: string
         description: Password of user attempting to authenticate
         example: '12345'
+      auth_source:
+        type: string
+        description: Identity provider to authenticate users against.
+        example: next
   authToken:
     description: An token used to authorize later requests
     type: string

--- a/tests/integration/server/auth_api_test.py
+++ b/tests/integration/server/auth_api_test.py
@@ -114,7 +114,7 @@ def test_missing_ldap_server():
         Test is skipped if LDAP server is set.
     """
     login_inputs = {"id": "susan20", "password": "123456", "auth_source": "ldap"}
-    expected = {"message": "Missing LDAP server information.", "code": 400}
+    expected = {"message": "Missing LDAP_SERVER env variable.", "code": 400}
     test_invalid_auth_inputs(
         login_inputs=login_inputs,
         expected_result=expected["message"],


### PR DESCRIPTION
AD auth was not working because LDAP3 python module requires
a distinguished name to bind (authenticate) instead of just
a username.

Documentation was updated for the /api/authorization endpoint
as this was missed when AD auth was first implemented.

Signed-off-by: mtn217 <michael.nguyen79@t-mobile.com>