### PR TITLE
Rbac wildcarding import removal

### DIFF
--- a/rbac/common/__init__.py
+++ b/rbac/common/__init__.py
@@ -12,35 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # -----------------------------------------------------------------------------
-"""The RBAC Common Library
-from rbac.common import rbac
-
-Exports a singleton class instance"""
-# pylint: disable=too-few-public-methods
-
-from rbac.common import addresser
-from rbac.common.user import USER as user
-from rbac.common.role import ROLE as role
-from rbac.common.task import TASK as task
-from rbac.common.key import KEY as key
-from rbac.common.logs import get_default_logger
-
-LOGGER = get_default_logger(__name__)
-
-
-class RbacLibrary:
-    """The RBAC Common Library"""
-
-    def __init__(self):
-        self.addresser = addresser
-        self.user = user
-        self.role = role
-        self.task = task
-        self.key = key
-
-
-# pylint: disable=invalid-name
-rbac = RbacLibrary()
-
-
-__all__ = ["rbac"]

--- a/rbac/ledger_sync/inbound/listener.py
+++ b/rbac/ledger_sync/inbound/listener.py
@@ -21,7 +21,7 @@ from rbac.common.logs import get_default_logger
 from rbac.common.sawtooth.client_sync import ClientSync
 from rbac.common.sawtooth.batcher import batch_to_list
 from rbac.ledger_sync.database import Database
-from rbac.providers.common.rbac_transactions import add_transaction
+from rbac.ledger_sync.inbound.rbac_transactions import add_transaction
 
 LOGGER = get_default_logger(__name__)
 

--- a/rbac/ledger_sync/inbound/rbac_transactions.py
+++ b/rbac/ledger_sync/inbound/rbac_transactions.py
@@ -17,7 +17,9 @@
 from uuid import uuid4
 
 from rbac.common.logs import get_default_logger
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.user import User
+from rbac.common.role import Role
 from rbac.common.crypto.keys import Key
 from rbac.common.util import bytes_from_hex
 
@@ -54,17 +56,17 @@ def add_transaction(inbound_entry):
 
             user_id = data["relationship_id"]
             next_id = str(uuid4())
-            object_id = rbac.user.hash(next_id)
-            address = rbac.user.address(object_id=object_id)
+            object_id = User().hash(next_id)
+            address = User().address(object_id=object_id)
 
             inbound_entry["address"] = bytes_from_hex(address)
             inbound_entry["object_id"] = bytes_from_hex(object_id)
-            inbound_entry["object_type"] = rbac.addresser.ObjectType.USER.value
+            inbound_entry["object_type"] = addresser.ObjectType.USER.value
 
-            message = rbac.user.imports.make(
+            message = User().imports.make(
                 signer_keypair=SIGNER_KEYPAIR, user_id=next_id, **data
             )
-            batch = rbac.user.imports.batch(
+            batch = User().imports.batch(
                 signer_keypair=SIGNER_KEYPAIR,
                 signer_user_id=SIGNER_USER_ID,
                 message=message,
@@ -76,17 +78,17 @@ def add_transaction(inbound_entry):
 
             role_id = data["relationship_id"]
             next_id = str(uuid4())
-            object_id = rbac.role.hash(next_id)
-            address = rbac.role.address(object_id=object_id)
+            object_id = Role().hash(next_id)
+            address = Role().address(object_id=object_id)
 
             inbound_entry["address"] = bytes_from_hex(address)
             inbound_entry["object_id"] = bytes_from_hex(object_id)
-            inbound_entry["object_type"] = rbac.addresser.ObjectType.ROLE.value
+            inbound_entry["object_type"] = addresser.ObjectType.ROLE.value
 
-            message = rbac.role.imports.make(
+            message = Role().imports.make(
                 signer_keypair=SIGNER_KEYPAIR, role_id=next_id, **data
             )
-            batch = rbac.role.imports.batch(
+            batch = Role().imports.batch(
                 signer_keypair=SIGNER_KEYPAIR,
                 signer_user_id=SIGNER_USER_ID,
                 message=message,

--- a/rbac/server/api/proposals.py
+++ b/rbac/server/api/proposals.py
@@ -17,17 +17,16 @@
 from sanic import Blueprint
 from sanic.response import json
 
-from rbac.common import rbac
+from rbac.common.user import User
+from rbac.common.role import Role
+from rbac.common.task import Task
 from rbac.common.logs import get_default_logger
-
 from rbac.server.api.errors import ApiBadRequest
 from rbac.server.api.auth import authorized
 from rbac.server.api import utils
-
 from rbac.server.db import proposals_query
 from rbac.server.db.relationships_query import fetch_relationships
 from rbac.server.db.users_query import fetch_user_resource
-
 from rbac.server.db import db_utils
 
 LOGGER = get_default_logger(__name__)
@@ -54,32 +53,32 @@ TABLES = {
 
 PROPOSAL_TRANSACTION = {
     "ADD_ROLE_TASK": {
-        "REJECTED": rbac.role.task.reject.batch_list,
-        "APPROVED": rbac.role.task.confirm.batch_list,
+        "REJECTED": Role().task.reject.batch_list,
+        "APPROVED": Role().task.confirm.batch_list,
     },
     "ADD_ROLE_MEMBER": {
-        "REJECTED": rbac.role.member.reject.batch_list,
-        "APPROVED": rbac.role.member.confirm.batch_list,
+        "REJECTED": Role().member.reject.batch_list,
+        "APPROVED": Role().member.confirm.batch_list,
     },
     "ADD_ROLE_OWNER": {
-        "REJECTED": rbac.role.owner.reject.batch_list,
-        "APPROVED": rbac.role.owner.confirm.batch_list,
+        "REJECTED": Role().owner.reject.batch_list,
+        "APPROVED": Role().owner.confirm.batch_list,
     },
     "ADD_ROLE_ADMIN": {
-        "REJECTED": rbac.role.admin.reject.batch_list,
-        "APPROVED": rbac.role.admin.confirm.batch_list,
+        "REJECTED": Role().admin.reject.batch_list,
+        "APPROVED": Role().admin.confirm.batch_list,
     },
     "ADD_TASK_OWNER": {
-        "REJECTED": rbac.task.owner.reject.batch_list,
-        "APPROVED": rbac.task.owner.confirm.batch_list,
+        "REJECTED": Task().owner.reject.batch_list,
+        "APPROVED": Task().owner.confirm.batch_list,
     },
     "ADD_TASK_ADMIN": {
-        "REJECTED": rbac.task.admin.reject.batch_list,
-        "APPROVED": rbac.task.admin.confirm.batch_list,
+        "REJECTED": Task().admin.reject.batch_list,
+        "APPROVED": Task().admin.confirm.batch_list,
     },
     "UPDATE_USER_MANAGER": {
-        "REJECTED": rbac.user.manager.reject.batch_list,
-        "APPROVED": rbac.user.manager.confirm.batch_list,
+        "REJECTED": User().manager.reject.batch_list,
+        "APPROVED": User().manager.confirm.batch_list,
     },
 }
 
@@ -147,7 +146,6 @@ async def update_proposal(request, proposal_id):
             "Bad Request: status must be either 'REJECTED' or 'APPROVED'"
         )
     txn_key, txn_user_id = await utils.get_transactor_key(request=request)
-    block = await utils.get_request_block(request)
 
     conn = await db_utils.create_connection(
         request.app.config.DB_HOST,

--- a/rbac/server/api/roles.py
+++ b/rbac/server/api/roles.py
@@ -19,13 +19,10 @@ from uuid import uuid4
 from sanic import Blueprint
 from sanic.response import json
 
-from rbac.common import rbac
-
+from rbac.common.role import Role
 from rbac.server.api.auth import authorized
 from rbac.server.api import utils
-
 from rbac.server.db import roles_query
-
 from rbac.server.db import db_utils
 
 ROLES_BP = Blueprint("roles")
@@ -59,7 +56,7 @@ async def create_new_role(request):
 
     txn_key, txn_user_id = await utils.get_transactor_key(request)
     role_id = str(uuid4())
-    batch_list = rbac.role.batch_list(
+    batch_list = Role().batch_list(
         signer_keypair=txn_key,
         signer_user_id=txn_user_id,
         name=request.json.get("name"),
@@ -99,7 +96,7 @@ async def update_role(request, role_id):
     utils.validate_fields(required_fields, request.json)
     txn_key, txn_user_id = await utils.get_transactor_key(request)
     role_description = request.json.get("description")
-    batch_list = rbac.role.update.batch_list(
+    batch_list = Role().update.batch_list(
         signer_keypair=txn_key,
         signer_user_id=txn_user_id,
         role_id=role_id,
@@ -120,7 +117,7 @@ async def add_role_admin(request, role_id):
 
     txn_key, txn_user_id = await utils.get_transactor_key(request)
     proposal_id = str(uuid4())
-    batch_list = rbac.role.admin.propose.batch_list(
+    batch_list = Role().admin.propose.batch_list(
         signer_keypair=txn_key,
         signer_user_id=txn_user_id,
         proposal_id=proposal_id,
@@ -143,7 +140,7 @@ async def add_role_member(request, role_id):
     utils.validate_fields(required_fields, request.json)
     txn_key, txn_user_id = await utils.get_transactor_key(request)
     proposal_id = str(uuid4())
-    batch_list = rbac.role.member.propose.batch_list(
+    batch_list = Role().member.propose.batch_list(
         signer_keypair=txn_key,
         signer_user_id=txn_user_id,
         proposal_id=proposal_id,
@@ -172,7 +169,7 @@ async def add_role_owner(request, role_id):
 
     txn_key, txn_user_id = await utils.get_transactor_key(request)
     proposal_id = str(uuid4())
-    batch_list = rbac.role.owner.propose.batch_list(
+    batch_list = Role().owner.propose.batch_list(
         signer_keypair=txn_key,
         signer_user_id=txn_user_id,
         proposal_id=proposal_id,
@@ -196,7 +193,7 @@ async def add_role_task(request, role_id):
 
     txn_key, txn_user_id = await utils.get_transactor_key(request)
     proposal_id = str(uuid4())
-    batch_list = rbac.role.task.propose.batch_list(
+    batch_list = Role().task.propose.batch_list(
         signer_keypair=txn_key,
         signer_user_id=txn_user_id,
         proposal_id=proposal_id,

--- a/rbac/server/api/tasks.py
+++ b/rbac/server/api/tasks.py
@@ -19,13 +19,10 @@ from uuid import uuid4
 from sanic import Blueprint
 from sanic.response import json
 
-from rbac.common import rbac
-
+from rbac.common.task import Task
 from rbac.server.api.auth import authorized
 from rbac.server.api import utils
-
 from rbac.server.db import tasks_query
-
 from rbac.server.db import db_utils
 
 TASKS_BP = Blueprint("tasks")
@@ -59,7 +56,7 @@ async def create_new_task(request):
 
     txn_key, txn_user_id = await utils.get_transactor_key(request)
     task_id = str(uuid4())
-    batch_list = rbac.task.batch_list(
+    batch_list = Task().batch_list(
         signer_keypair=txn_key,
         signer_user_id=txn_user_id,
         task_id=task_id,
@@ -99,7 +96,7 @@ async def add_task_admin(request, task_id):
 
     txn_key, txn_user_id = await utils.get_transactor_key(request)
     proposal_id = str(uuid4())
-    batch_list = rbac.task.admin.propose.batch_list(
+    batch_list = Task().admin.propose.batch_list(
         signer_keypair=txn_key,
         signer_user_id=txn_user_id,
         proposal_id=proposal_id,
@@ -123,7 +120,7 @@ async def add_task_owner(request, task_id):
 
     txn_key, txn_user_id = await utils.get_transactor_key(request)
     proposal_id = str(uuid4())
-    batch_list = rbac.task.owner.propose.batch_list(
+    batch_list = Task().owner.propose.batch_list(
         signer_keypair=txn_key,
         signer_user_id=txn_user_id,
         proposal_id=proposal_id,

--- a/rbac/server/api/users.py
+++ b/rbac/server/api/users.py
@@ -20,7 +20,7 @@ import hashlib
 from sanic import Blueprint
 from sanic.response import json
 
-from rbac.common import rbac
+from rbac.common.user import User
 from rbac.common.crypto.keys import Key
 from rbac.common.crypto.secrets import encrypt_private_key
 
@@ -72,13 +72,13 @@ async def create_new_user(request):
 
     # Generate keys
     txn_key = Key()
-    txn_user_id = rbac.user.unique_id()
+    txn_user_id = User().unique_id()
     encrypted_private_key = encrypt_private_key(
         request.app.config.AES_KEY, txn_key.public_key, txn_key.private_key_bytes
     )
 
     # Build create user transaction
-    batch_list = rbac.user.batch_list(
+    batch_list = User().batch_list(
         signer_keypair=txn_key,
         signer_user_id=txn_user_id,
         user_id=txn_user_id,
@@ -204,7 +204,7 @@ async def update_manager(request, user_id):
 
     txn_key, txn_user_id = await utils.get_transactor_key(request)
     proposal_id = str(uuid4())
-    batch_list = rbac.user.manager.propose.batch_list(
+    batch_list = User().manager.propose.batch_list(
         signer_keypair=txn_key,
         signer_user_id=txn_user_id,
         proposal_id=proposal_id,
@@ -330,7 +330,6 @@ async def fetch_rejected_proposals(request, user_id):
 @authorized()
 async def update_expired_roles(request, user_id):
     """Manually expire user role membership"""
-    head_block = await utils.get_request_block(request)
     required_fields = ["id"]
     utils.validate_fields(required_fields, request.json)
 

--- a/rbac/server/db/auth_query.py
+++ b/rbac/server/db/auth_query.py
@@ -16,7 +16,7 @@
 
 import rethinkdb as r
 
-from rbac.common import rbac
+from rbac.common.key import KEY
 from rbac.common.logs import get_default_logger
 from rbac.common.crypto.keys import Key
 from rbac.common.crypto.secrets import encrypt_private_key
@@ -74,7 +74,7 @@ async def fetch_info_by_username(request):
     user_id = result.get("user_id")
     user_key = Key()
 
-    batch_list = rbac.key.batch_list(
+    batch_list = KEY.batch_list(
         signer_keypair=user_key,
         signer_user_id=user_id,
         user_id=user_id,

--- a/tests/blockchain/rbac_client.py
+++ b/tests/blockchain/rbac_client.py
@@ -15,7 +15,9 @@
 """Test suite for the sawtooth REST client."""
 
 from uuid import uuid4
-from rbac.common import rbac
+from rbac.common.user import User
+from rbac.common.role import Role
+from rbac.common.task import Task
 from rbac.common.sawtooth import batcher
 
 from rbac.common.sawtooth.rest_client import RestClient
@@ -34,7 +36,7 @@ class RbacClient(object):
 
     def create_user(self, key, name, username, user_id, manager_id=None):
         """Create a new user."""
-        batch_list = rbac.user.batch_list(
+        batch_list = User().batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             name=name,
@@ -49,7 +51,7 @@ class RbacClient(object):
 
     def create_role(self, key, role_name, role_id, metadata, admins, owners):
         """Create a new role."""
-        batch_list = rbac.role.batch_list(
+        batch_list = Role().batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             name=role_name,
@@ -66,7 +68,7 @@ class RbacClient(object):
         self, key, proposal_id, user_id, new_manager_id, reason, metadata
     ):
         """Propose an update of user's manager."""
-        batch_list = rbac.user.manager.propose.batch_list(
+        batch_list = User().manager.propose.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -81,7 +83,7 @@ class RbacClient(object):
 
     def confirm_update_manager(self, key, proposal_id, reason, user_id, manager_id):
         """Confirm the update of a user's manager."""
-        batch_list = rbac.user.manager.confirm.batch_list(
+        batch_list = User().manager.confirm.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -95,7 +97,7 @@ class RbacClient(object):
 
     def reject_update_manager(self, key, proposal_id, reason, user_id, manager_id):
         """Reject the update of a user's manager."""
-        batch_list = rbac.user.manager.reject.batch_list(
+        batch_list = User().manager.reject.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -111,7 +113,7 @@ class RbacClient(object):
         self, key, proposal_id, role_id, user_id, reason, metadata
     ):
         """Propose adding admin to role."""
-        batch_list = rbac.role.admin.propose.batch_list(
+        batch_list = Role().admin.propose.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -126,7 +128,7 @@ class RbacClient(object):
 
     def confirm_add_role_admins(self, key, proposal_id, role_id, user_id, reason):
         """Confirm addition of admin to role."""
-        batch_list = rbac.role.admin.confirm.batch_list(
+        batch_list = Role().admin.confirm.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -140,7 +142,7 @@ class RbacClient(object):
 
     def reject_add_role_admins(self, key, proposal_id, role_id, user_id, reason):
         """Reject addition of admin to role."""
-        batch_list = rbac.role.admin.reject.batch_list(
+        batch_list = Role().admin.reject.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -156,7 +158,7 @@ class RbacClient(object):
         self, key, proposal_id, role_id, user_id, reason, metadata
     ):
         """Propose adding owner to role."""
-        batch_list = rbac.role.owner.propose.batch_list(
+        batch_list = Role().owner.propose.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -171,7 +173,7 @@ class RbacClient(object):
 
     def confirm_add_role_owners(self, key, proposal_id, role_id, user_id, reason):
         """Confirm addition of owner to role."""
-        batch_list = rbac.role.owner.confirm.batch_list(
+        batch_list = Role().owner.confirm.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -185,7 +187,7 @@ class RbacClient(object):
 
     def reject_add_role_owners(self, key, proposal_id, role_id, user_id, reason):
         """Reject addition of role owner."""
-        batch_list = rbac.role.owner.reject.batch_list(
+        batch_list = Role().owner.reject.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -201,7 +203,7 @@ class RbacClient(object):
         self, key, proposal_id, role_id, user_id, reason, metadata
     ):
         """Propose adding role member."""
-        batch_list = rbac.role.member.propose.batch_list(
+        batch_list = Role().member.propose.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -216,7 +218,7 @@ class RbacClient(object):
 
     def confirm_add_role_members(self, key, proposal_id, role_id, user_id, reason):
         """Confirm addition of role member."""
-        batch_list = rbac.role.member.confirm.batch_list(
+        batch_list = Role().member.confirm.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -230,7 +232,7 @@ class RbacClient(object):
 
     def reject_add_role_members(self, key, proposal_id, role_id, user_id, reason):
         """Reject addition of role member."""
-        batch_list = rbac.role.member.reject.batch_list(
+        batch_list = Role().member.reject.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -246,7 +248,7 @@ class RbacClient(object):
         self, key, proposal_id, role_id, task_id, reason, metadata
     ):
         """Propose adding task to role."""
-        batch_list = rbac.role.task.propose.batch_list(
+        batch_list = Role().task.propose.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -261,7 +263,7 @@ class RbacClient(object):
 
     def confirm_add_role_tasks(self, key, proposal_id, role_id, task_id, reason):
         """Confirm addition of task to role."""
-        batch_list = rbac.role.task.confirm.batch_list(
+        batch_list = Role().task.confirm.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -275,7 +277,7 @@ class RbacClient(object):
 
     def reject_add_role_tasks(self, key, proposal_id, role_id, task_id, reason):
         """Reject addition of task to role."""
-        batch_list = rbac.role.task.reject.batch_list(
+        batch_list = Role().task.reject.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -289,7 +291,7 @@ class RbacClient(object):
 
     def create_task(self, key, task_id, task_name, admins, owners, metadata):
         """Create a new task."""
-        batch_list = rbac.task.batch_list(
+        batch_list = Task().batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             task_id=task_id,
@@ -306,7 +308,7 @@ class RbacClient(object):
         self, key, proposal_id, task_id, user_id, reason, metadata
     ):
         """Propose adding a task admin."""
-        batch_list = rbac.task.admin.propose.batch_list(
+        batch_list = Task().admin.propose.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -321,7 +323,7 @@ class RbacClient(object):
 
     def confirm_add_task_admins(self, key, proposal_id, task_id, user_id, reason):
         """Confirm addition of task admin."""
-        batch_list = rbac.task.admin.confirm.batch_list(
+        batch_list = Task().admin.confirm.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -335,7 +337,7 @@ class RbacClient(object):
 
     def reject_add_task_admins(self, key, proposal_id, task_id, user_id, reason):
         """Reject addition of task admin."""
-        batch_list = rbac.task.admin.reject.batch_list(
+        batch_list = Task().admin.reject.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -351,7 +353,7 @@ class RbacClient(object):
         self, key, proposal_id, task_id, user_id, reason, metadata
     ):
         """Propose adding a task owner."""
-        batch_list = rbac.task.owner.propose.batch_list(
+        batch_list = Task().owner.propose.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -366,7 +368,7 @@ class RbacClient(object):
 
     def confirm_add_task_owners(self, key, proposal_id, task_id, user_id, reason):
         """Confirm addition of task owner."""
-        batch_list = rbac.task.owner.confirm.batch_list(
+        batch_list = Task().owner.confirm.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,
@@ -380,7 +382,7 @@ class RbacClient(object):
 
     def reject_add_task_owners(self, key, proposal_id, task_id, user_id, reason):
         """Reject addition of task owner."""
-        batch_list = rbac.task.owner.reject.batch_list(
+        batch_list = Task().owner.reject.batch_list(
             signer_keypair=key,
             signer_user_id=key.public_key,
             proposal_id=proposal_id,

--- a/tests/rbac/common/base/base_message.py
+++ b/tests/rbac/common/base/base_message.py
@@ -17,7 +17,7 @@
 
 import pytest
 
-from rbac.common import rbac
+from rbac.common.user import User
 from rbac.common import protobuf
 from rbac.common.sawtooth.batcher import unmake
 from rbac.common.logs import get_default_logger
@@ -32,7 +32,7 @@ def test_make_message():
     """Test making a message"""
     name = helper.user.name()
     keypair = helper.user.key()
-    message = rbac.user.make(user_id=keypair.public_key, name=name)
+    message = User().make(user_id=keypair.public_key, name=name)
     assert isinstance(message, protobuf.user_transaction_pb2.CreateUser)
     assert isinstance(message.user_id, str)
     assert isinstance(message.name, str)
@@ -47,10 +47,10 @@ def test_make_payload():
     name = helper.user.name()
     user_key = helper.user.key()
     user_id = user_key.public_key
-    user_address = rbac.user.address(object_id=user_id)
-    message = rbac.user.make(user_id=user_id, name=name)
+    user_address = User().address(object_id=user_id)
+    message = User().make(user_id=user_id, name=name)
 
-    payload = rbac.user.make_payload(
+    payload = User().make_payload(
         message=message, signer_user_id=user_id, signer_keypair=user_key
     )
     inputs = list(payload.inputs)
@@ -68,9 +68,9 @@ def test_batch_with_message():
     name = helper.user.name()
     user_key = helper.user.key()
     user_id = user_key.public_key
-    message = rbac.user.make(user_id=user_id, name=name)
+    message = User().make(user_id=user_id, name=name)
 
-    batch = rbac.user.batch(
+    batch = User().batch(
         signer_user_id=user_id, signer_keypair=user_key, message=message
     )
 
@@ -88,7 +88,7 @@ def test_batch_with_kargs():
     user_key = helper.user.key()
     user_id = user_key.public_key
 
-    batch = rbac.user.batch(
+    batch = User().batch(
         signer_user_id=user_id, signer_keypair=user_key, user_id=user_id, name=name
     )
 
@@ -105,18 +105,18 @@ def test_batch_add_with_message():
     name1 = helper.user.name()
     user_key1 = helper.user.key()
     user_id1 = user_key1.public_key
-    message1 = rbac.user.make(user_id=user_id1, name=name1)
+    message1 = User().make(user_id=user_id1, name=name1)
 
     name2 = helper.user.name()
     user_key2 = helper.user.key()
     user_id2 = user_key2.public_key
-    message2 = rbac.user.make(user_id=user_id2, name=name2)
+    message2 = User().make(user_id=user_id2, name=name2)
 
-    batch = rbac.user.batch(
+    batch = User().batch(
         signer_user_id=user_id1, signer_keypair=user_key1, message=message1
     )
 
-    batch = rbac.user.batch(
+    batch = User().batch(
         signer_user_id=user_id2, signer_keypair=user_key2, message=message2, batch=batch
     )
 
@@ -140,11 +140,11 @@ def test_batch_add_with_kargs():
     user_key2 = helper.user.key()
     user_id2 = user_key2.public_key
 
-    batch = rbac.user.batch(
+    batch = User().batch(
         signer_user_id=user_id1, signer_keypair=user_key1, user_id=user_id1, name=name1
     )
 
-    batch = rbac.user.batch(
+    batch = User().batch(
         signer_user_id=user_id2,
         signer_keypair=user_key2,
         user_id=user_id2,
@@ -167,9 +167,9 @@ def test_batch_list_with_message():
     name = helper.user.name()
     user_key = helper.user.key()
     user_id = user_key.public_key
-    message = rbac.user.make(user_id=user_id, name=name)
+    message = User().make(user_id=user_id, name=name)
 
-    batch_list = rbac.user.batch_list(
+    batch_list = User().batch_list(
         signer_user_id=user_id, signer_keypair=user_key, message=message
     )
 
@@ -187,7 +187,7 @@ def test_batch_list_with_kargs():
     user_key = helper.user.key()
     user_id = user_key.public_key
 
-    batch_list = rbac.user.batch_list(
+    batch_list = User().batch_list(
         signer_user_id=user_id, signer_keypair=user_key, user_id=user_id, name=name
     )
 
@@ -204,18 +204,18 @@ def test_batch_list_add_with_message():
     name1 = helper.user.name()
     user_key1 = helper.user.key()
     user_id1 = user_key1.public_key
-    message1 = rbac.user.make(user_id=user_id1, name=name1)
+    message1 = User().make(user_id=user_id1, name=name1)
 
     name2 = helper.user.name()
     user_key2 = helper.user.key()
     user_id2 = user_key2.public_key
-    message2 = rbac.user.make(user_id=user_id2, name=name2)
+    message2 = User().make(user_id=user_id2, name=name2)
 
-    batch_list = rbac.user.batch_list(
+    batch_list = User().batch_list(
         signer_user_id=user_id2, signer_keypair=user_key1, message=message1
     )
 
-    batch_list = rbac.user.batch_list(
+    batch_list = User().batch_list(
         signer_user_id=user_id2,
         signer_keypair=user_key2,
         message=message2,
@@ -242,11 +242,11 @@ def test_batch_list_add_with_kargs():
     user_key2 = helper.user.key()
     user_id2 = user_key2.public_key
 
-    batch_list = rbac.user.batch_list(
+    batch_list = User().batch_list(
         signer_user_id=user_id1, signer_keypair=user_key1, user_id=user_id1, name=name1
     )
 
-    batch_list = rbac.user.batch_list(
+    batch_list = User().batch_list(
         signer_user_id=user_id2,
         signer_keypair=user_key2,
         user_id=user_id2,
@@ -269,13 +269,13 @@ def test_create_with_kargs():
     user_key = helper.user.key()
     user_id = user_key.public_key
 
-    status = rbac.user.new(
+    status = User().new(
         signer_user_id=user_id, signer_keypair=user_key, user_id=user_id, name=name
     )
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    user = rbac.user.get(object_id=user_id)
+    user = User().get(object_id=user_id)
     assert user.user_id == user_id
     assert user.name == name
 
@@ -286,15 +286,15 @@ def test_create_with_message():
     name = helper.user.name()
     user_key = helper.user.key()
     user_id = user_key.public_key
-    message = rbac.user.make(user_id=user_id, name=name)
+    message = User().make(user_id=user_id, name=name)
 
-    status = rbac.user.new(
+    status = User().new(
         signer_user_id=user_id, signer_keypair=user_key, message=message
     )
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    user = rbac.user.get(object_id=user_id)
+    user = User().get(object_id=user_id)
     assert user.user_id == user_id
     assert user.name == name
 
@@ -309,6 +309,6 @@ def test_make_payload_with_wrong_message_type():
         user_id=user_id, name=helper.user.name(), metadata=None
     )
     with pytest.raises(TypeError):
-        rbac.user.make_payload(
+        User().make_payload(
             message=message, signer_user_id=user_id, signer_keypair=signer_keypair
         )

--- a/tests/rbac/common/key/add_key_test.py
+++ b/tests/rbac/common/key/add_key_test.py
@@ -18,7 +18,8 @@
 
 import pytest
 
-from rbac.common import rbac
+from rbac.common.user import User
+from rbac.common.key import Key
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -33,7 +34,7 @@ def test_make():
     """
     user_id = helper.user.id()
     keypair = helper.user.key()
-    message = rbac.key.make(user_id=user_id, key_id=keypair.public_key)
+    message = Key().make(user_id=user_id, key_id=keypair.public_key)
     assert isinstance(message, protobuf.key_transaction_pb2.AddKey)
     assert message.user_id == user_id
     assert message.key_id == keypair.public_key
@@ -46,12 +47,12 @@ def test_make_addresses():
     """
     user_id = helper.user.id()
     keypair = helper.user.key()
-    message = rbac.key.make(user_id=user_id, key_id=keypair.public_key)
-    inputs, outputs = rbac.key.make_addresses(message=message, signer_user_id=user_id)
+    message = Key().make(user_id=user_id, key_id=keypair.public_key)
+    inputs, outputs = Key().make_addresses(message=message, signer_user_id=user_id)
 
-    user_address = rbac.user.address(object_id=user_id)
-    key_address = rbac.key.address(object_id=keypair.public_key)
-    user_key_address = rbac.user.key.address(
+    user_address = User().address(object_id=user_id)
+    key_address = Key().address(object_id=keypair.public_key)
+    user_key_address = User().key.address(
         object_id=user_id, related_id=keypair.public_key
     )
 
@@ -72,7 +73,7 @@ def test_add_key():
     user = helper.user.imports()
     new_key = helper.user.key()
 
-    status = rbac.key.new(
+    status = Key().new(
         signer_keypair=new_key,
         signer_user_id=user.user_id,
         user_id=user.user_id,
@@ -82,4 +83,4 @@ def test_add_key():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    assert rbac.user.key.exists(object_id=user.user_id, related_id=new_key.public_key)
+    assert User().key.exists(object_id=user.user_id, related_id=new_key.public_key)

--- a/tests/rbac/common/proposal/proposal_helper.py
+++ b/tests/rbac/common/proposal/proposal_helper.py
@@ -17,7 +17,7 @@
 
 import random
 
-from rbac.common import rbac
+from rbac.common import addresser
 from rbac.common.logs import get_default_logger
 
 LOGGER = get_default_logger(__name__)
@@ -28,7 +28,7 @@ class ProposalTestHelper:
 
     def id(self):
         """Get a test proposal_id (not created)"""
-        return rbac.addresser.proposal.unique_id()
+        return addresser.proposal.unique_id()
 
     def reason(self):
         """Get a random reason"""

--- a/tests/rbac/common/role/confirm_admin_test.py
+++ b/tests/rbac/common/role/confirm_admin_test.py
@@ -16,7 +16,8 @@
 # pylint: disable=no-member,too-many-locals
 import pytest
 
-from rbac.common import rbac
+from rbac.common.role import Role
+from rbac.common.user import User
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -34,7 +35,7 @@ def test_make():
     proposal_id = helper.proposal.id()
     reason = helper.proposal.reason()
     signer_user_id = helper.user.id()
-    message = rbac.role.admin.confirm.make(
+    message = Role().admin.confirm.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
@@ -55,14 +56,14 @@ def test_make_addresses():
     related_id = helper.user.id()
     object_id = helper.role.id()
     proposal_id = helper.proposal.id()
-    proposal_address = rbac.role.admin.propose.address(object_id, related_id)
+    proposal_address = Role().admin.propose.address(object_id, related_id)
     reason = helper.proposal.reason()
-    relationship_address = rbac.role.admin.address(object_id, related_id)
+    relationship_address = Role().admin.address(object_id, related_id)
     signer_user_id = helper.user.id()
 
-    user_address = rbac.user.address(related_id)
-    signer_admin_address = rbac.role.admin.address(object_id, signer_user_id)
-    message = rbac.role.admin.confirm.make(
+    user_address = User().address(related_id)
+    signer_admin_address = Role().admin.address(object_id, signer_user_id)
+    message = Role().admin.confirm.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
@@ -70,7 +71,7 @@ def test_make_addresses():
         signer_user_id=signer_user_id,
     )
 
-    inputs, outputs = rbac.role.admin.confirm.make_addresses(
+    inputs, outputs = Role().admin.confirm.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -91,7 +92,7 @@ def test_create():
 
     reason = helper.role.admin.propose.reason()
 
-    status = rbac.role.admin.confirm.new(
+    status = Role().admin.confirm.new(
         signer_keypair=role_admin_key,
         signer_user_id=role_admin.user_id,
         proposal_id=proposal.proposal_id,
@@ -103,7 +104,7 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    confirm = rbac.role.admin.confirm.get(
+    confirm = Role().admin.confirm.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 
@@ -115,6 +116,6 @@ def test_create():
     assert confirm.close_reason == reason
     assert confirm.closer == role_admin.user_id
     assert confirm.status == protobuf.proposal_state_pb2.Proposal.CONFIRMED
-    assert rbac.role.admin.exists(
+    assert Role().admin.exists(
         object_id=proposal.object_id, related_id=proposal.related_id
     )

--- a/tests/rbac/common/role/confirm_member_test.py
+++ b/tests/rbac/common/role/confirm_member_test.py
@@ -18,7 +18,8 @@
 
 import pytest
 
-from rbac.common import rbac
+from rbac.common.role import Role
+from rbac.common.user import User
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -34,7 +35,7 @@ def test_make():
     object_id = helper.role.id()
     proposal_id = helper.proposal.id()
     reason = helper.proposal.reason()
-    message = rbac.role.member.confirm.make(
+    message = Role().member.confirm.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
@@ -54,22 +55,22 @@ def test_make_addresses():
     related_id = helper.user.id()
     object_id = helper.role.id()
     proposal_id = helper.proposal.id()
-    proposal_address = rbac.role.member.propose.address(object_id, related_id)
+    proposal_address = Role().member.propose.address(object_id, related_id)
     reason = helper.proposal.reason()
-    relationship_address = rbac.role.member.address(object_id, related_id)
+    relationship_address = Role().member.address(object_id, related_id)
     signer_user_id = helper.user.id()
 
-    user_address = rbac.user.address(related_id)
-    signer_admin_address = rbac.role.admin.address(object_id, signer_user_id)
-    signer_owner_address = rbac.role.owner.address(object_id, signer_user_id)
-    message = rbac.role.member.confirm.make(
+    user_address = User().address(related_id)
+    signer_admin_address = Role().admin.address(object_id, signer_user_id)
+    signer_owner_address = Role().owner.address(object_id, signer_user_id)
+    message = Role().member.confirm.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
         reason=reason,
     )
 
-    inputs, outputs = rbac.role.member.confirm.make_addresses(
+    inputs, outputs = Role().member.confirm.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -91,7 +92,7 @@ def test_create():
 
     reason = helper.role.member.propose.reason()
 
-    status = rbac.role.member.confirm.new(
+    status = Role().member.confirm.new(
         signer_keypair=role_owner_key,
         signer_user_id=role_owner.user_id,
         proposal_id=proposal.proposal_id,
@@ -103,7 +104,7 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    confirm = rbac.role.member.confirm.get(
+    confirm = Role().member.confirm.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 
@@ -115,6 +116,6 @@ def test_create():
     assert confirm.close_reason == reason
     assert confirm.closer == role_owner.user_id
     assert confirm.status == protobuf.proposal_state_pb2.Proposal.CONFIRMED
-    assert rbac.role.member.exists(
+    assert Role().member.exists(
         object_id=proposal.object_id, related_id=proposal.related_id
     )

--- a/tests/rbac/common/role/confirm_owner_test.py
+++ b/tests/rbac/common/role/confirm_owner_test.py
@@ -18,7 +18,8 @@
 
 import pytest
 
-from rbac.common import rbac
+from rbac.common.role import Role
+from rbac.common.user import User
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -34,7 +35,7 @@ def test_make():
     object_id = helper.role.id()
     proposal_id = helper.proposal.id()
     reason = helper.proposal.reason()
-    message = rbac.role.owner.confirm.make(
+    message = Role().owner.confirm.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
@@ -54,22 +55,22 @@ def test_make_addresses():
     related_id = helper.user.id()
     object_id = helper.role.id()
     proposal_id = helper.proposal.id()
-    proposal_address = rbac.role.owner.propose.address(object_id, related_id)
+    proposal_address = Role().owner.propose.address(object_id, related_id)
     reason = helper.proposal.reason()
-    relationship_address = rbac.role.owner.address(object_id, related_id)
+    relationship_address = Role().owner.address(object_id, related_id)
     signer_user_id = helper.user.id()
 
-    user_address = rbac.user.address(related_id)
-    signer_admin_address = rbac.role.admin.address(object_id, signer_user_id)
-    signer_owner_address = rbac.role.owner.address(object_id, signer_user_id)
-    message = rbac.role.owner.confirm.make(
+    user_address = User().address(related_id)
+    signer_admin_address = Role().admin.address(object_id, signer_user_id)
+    signer_owner_address = Role().owner.address(object_id, signer_user_id)
+    message = Role().owner.confirm.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
         reason=reason,
     )
 
-    inputs, outputs = rbac.role.owner.confirm.make_addresses(
+    inputs, outputs = Role().owner.confirm.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -90,14 +91,14 @@ def test_create():
     proposal, _, role_owner, role_owner_key, _, _ = helper.role.owner.propose.create()
 
     reason = helper.role.owner.propose.reason()
-    message = rbac.role.owner.confirm.make(
+    message = Role().owner.confirm.make(
         proposal_id=proposal.proposal_id,
         object_id=proposal.object_id,
         related_id=proposal.related_id,
         reason=reason,
     )
 
-    status = rbac.role.owner.confirm.new(
+    status = Role().owner.confirm.new(
         signer_keypair=role_owner_key,
         signer_user_id=role_owner.user_id,
         message=message,
@@ -108,7 +109,7 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    confirm = rbac.role.owner.confirm.get(
+    confirm = Role().owner.confirm.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 
@@ -120,6 +121,6 @@ def test_create():
     assert confirm.close_reason == reason
     assert confirm.closer == role_owner.user_id
     assert confirm.status == protobuf.proposal_state_pb2.Proposal.CONFIRMED
-    assert rbac.role.owner.exists(
+    assert Role().owner.exists(
         object_id=proposal.object_id, related_id=proposal.related_id
     )

--- a/tests/rbac/common/role/confirm_task_test.py
+++ b/tests/rbac/common/role/confirm_task_test.py
@@ -18,7 +18,8 @@
 
 import pytest
 
-from rbac.common import rbac
+from rbac.common.role import Role
+from rbac.common.task import Task
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -34,7 +35,7 @@ def test_make():
     object_id = helper.role.id()
     proposal_id = helper.proposal.id()
     reason = helper.proposal.reason()
-    message = rbac.role.task.confirm.make(
+    message = Role().task.confirm.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
@@ -54,19 +55,19 @@ def test_make_addresses():
     related_id = helper.task.id()
     object_id = helper.role.id()
     proposal_id = helper.proposal.id()
-    proposal_address = rbac.role.task.propose.address(object_id, related_id)
+    proposal_address = Role().task.propose.address(object_id, related_id)
     reason = helper.proposal.reason()
-    relationship_address = rbac.role.task.address(object_id, related_id)
+    relationship_address = Role().task.address(object_id, related_id)
     signer_user_id = helper.user.id()
-    task_owner_address = rbac.task.owner.address(related_id, signer_user_id)
-    message = rbac.role.task.confirm.make(
+    task_owner_address = Task().owner.address(related_id, signer_user_id)
+    message = Role().task.confirm.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
         reason=reason,
     )
 
-    inputs, outputs = rbac.role.task.confirm.make_addresses(
+    inputs, outputs = Role().task.confirm.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -85,14 +86,14 @@ def test_create():
     proposal, _, _, _, _, task_owner, task_owner_key = helper.role.task.propose.create()
 
     reason = helper.role.task.propose.reason()
-    message = rbac.role.task.confirm.make(
+    message = Role().task.confirm.make(
         proposal_id=proposal.proposal_id,
         object_id=proposal.object_id,
         related_id=proposal.related_id,
         reason=reason,
     )
 
-    status = rbac.role.task.confirm.new(
+    status = Role().task.confirm.new(
         signer_keypair=task_owner_key,
         signer_user_id=task_owner.user_id,
         message=message,
@@ -103,7 +104,7 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    confirm = rbac.role.task.confirm.get(
+    confirm = Role().task.confirm.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 
@@ -115,6 +116,6 @@ def test_create():
     assert confirm.close_reason == reason
     assert confirm.closer == task_owner.user_id
     assert confirm.status == protobuf.proposal_state_pb2.Proposal.CONFIRMED
-    assert rbac.role.task.exists(
+    assert Role().task.exists(
         object_id=proposal.object_id, related_id=proposal.related_id
     )

--- a/tests/rbac/common/role/create_role_helper.py
+++ b/tests/rbac/common/role/create_role_helper.py
@@ -15,7 +15,7 @@
 """Create Role test helper"""
 # pylint: disable=no-member,too-few-public-methods
 
-from rbac.common import rbac
+from rbac.common.role import Role
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common.user.create_user_helper import CreateUserTestHelper
@@ -43,7 +43,7 @@ class CreateRoleTestHelper(RoleTestData):
         role_id = self.id()
         name = self.name()
         user_id = helper.user.id()
-        message = rbac.role.make(
+        message = Role().make(
             role_id=role_id, name=name, owners=[user_id], admins=[user_id]
         )
         assert isinstance(message, protobuf.role_transaction_pb2.CreateRole)
@@ -56,21 +56,21 @@ class CreateRoleTestHelper(RoleTestData):
         role_id = self.id()
         name = self.name()
         user, keypair = helper.user.create()
-        message = rbac.role.make(
+        message = Role().make(
             role_id=role_id, name=name, owners=[user.user_id], admins=[user.user_id]
         )
 
-        status = rbac.role.new(
+        status = Role().new(
             signer_keypair=keypair, signer_user_id=user.user_id, message=message
         )
 
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
-        role = rbac.role.get(object_id=message.role_id)
+        role = Role().get(object_id=message.role_id)
 
         assert role.role_id == message.role_id
         assert role.name == message.name
-        assert rbac.role.owner.exists(object_id=role.role_id, related_id=user.user_id)
-        assert rbac.role.admin.exists(object_id=role.role_id, related_id=user.user_id)
+        assert Role().owner.exists(object_id=role.role_id, related_id=user.user_id)
+        assert Role().admin.exists(object_id=role.role_id, related_id=user.user_id)
         return role, user, keypair

--- a/tests/rbac/common/role/create_role_test.py
+++ b/tests/rbac/common/role/create_role_test.py
@@ -18,7 +18,9 @@
 
 import pytest
 
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.role import Role
+from rbac.common.user import User
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -33,8 +35,8 @@ LOGGER = get_default_logger(__name__)
 def test_address():
     """Test the address method and that it is in sync with the addresser"""
     role_id = helper.role.id()
-    address1 = rbac.role.address(object_id=role_id)
-    address2 = rbac.addresser.role.address(role_id)
+    address1 = Role().address(object_id=role_id)
+    address2 = addresser.role.address(role_id)
     assert address1 == address2
 
 
@@ -46,7 +48,7 @@ def test_make():
     description = helper.role.description()
     role_id = helper.role.id()
     user_id = helper.user.id()
-    message = rbac.role.make(
+    message = Role().make(
         role_id=role_id,
         name=name,
         owners=[user_id],
@@ -69,17 +71,17 @@ def test_make_addresses():
     """Test the make addresses method for the message"""
     name = helper.role.name()
     role_id = helper.role.id()
-    role_address = rbac.role.address(role_id)
+    role_address = Role().address(role_id)
     user_id = helper.user.id()
-    user_address = rbac.user.address(user_id)
+    user_address = User().address(user_id)
     signer_user_id = helper.user.id()
-    owner_address = rbac.role.owner.address(role_id, user_id)
-    admin_address = rbac.role.admin.address(role_id, user_id)
-    message = rbac.role.make(
+    owner_address = Role().owner.address(role_id, user_id)
+    admin_address = Role().admin.address(role_id, user_id)
+    message = Role().make(
         role_id=role_id, name=name, owners=[user_id], admins=[user_id]
     )
 
-    inputs, outputs = rbac.role.make_addresses(
+    inputs, outputs = Role().make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -102,7 +104,7 @@ def test_create():
     name = helper.role.name()
     description = helper.role.description()
     role_id = helper.role.id()
-    message = rbac.role.make(
+    message = Role().make(
         role_id=role_id,
         name=name,
         owners=[user.user_id],
@@ -110,17 +112,17 @@ def test_create():
         description=description,
     )
 
-    status = rbac.role.new(
+    status = Role().new(
         signer_keypair=keypair, signer_user_id=user.user_id, message=message
     )
 
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    role = rbac.role.get(object_id=role_id)
+    role = Role().get(object_id=role_id)
 
     assert role.role_id == message.role_id
     assert role.name == message.name
     assert role.description == message.description
-    assert rbac.role.owner.exists(object_id=role.role_id, related_id=user.user_id)
-    assert rbac.role.admin.exists(object_id=role.role_id, related_id=user.user_id)
+    assert Role().owner.exists(object_id=role.role_id, related_id=user.user_id)
+    assert Role().admin.exists(object_id=role.role_id, related_id=user.user_id)

--- a/tests/rbac/common/role/imports_role_test.py
+++ b/tests/rbac/common/role/imports_role_test.py
@@ -18,7 +18,8 @@
 
 import pytest
 
-from rbac.common import rbac
+from rbac.common.role import Role
+from rbac.common.user import User
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -34,7 +35,7 @@ def test_make():
     name = helper.role.name()
     role_id = helper.role.id()
     user_id = helper.user.id()
-    message = rbac.role.imports.make(
+    message = Role().imports.make(
         role_id=role_id, name=name, owners=[user_id], admins=[user_id]
     )
     assert isinstance(message, protobuf.role_transaction_pb2.ImportsRole)
@@ -53,17 +54,17 @@ def test_make_addresses():
     """Test the make addresses method for the message"""
     name = helper.role.name()
     role_id = helper.role.id()
-    role_address = rbac.role.address(role_id)
+    role_address = Role().address(role_id)
     user_id = helper.user.id()
-    user_address = rbac.user.address(user_id)
+    user_address = User().address(user_id)
     signer_user_id = helper.user.id()
-    owner_address = rbac.role.owner.address(role_id, user_id)
-    admin_address = rbac.role.admin.address(role_id, user_id)
-    message = rbac.role.imports.make(
+    owner_address = Role().owner.address(role_id, user_id)
+    admin_address = Role().admin.address(role_id, user_id)
+    message = Role().imports.make(
         role_id=role_id, name=name, owners=[user_id], admins=[user_id]
     )
 
-    inputs, outputs = rbac.role.imports.make_addresses(
+    inputs, outputs = Role().imports.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -86,7 +87,7 @@ def test_create():
     name = helper.role.name()
     role_id = helper.role.id()
 
-    status = rbac.role.imports.new(
+    status = Role().imports.new(
         signer_keypair=keypair,
         signer_user_id=user.user_id,
         role_id=role_id,
@@ -99,10 +100,10 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    role = rbac.role.get(object_id=role_id)
+    role = Role().get(object_id=role_id)
 
     assert role.role_id == role_id
     assert role.name == name
-    assert rbac.role.owner.exists(object_id=role.role_id, related_id=user.user_id)
-    assert rbac.role.admin.exists(object_id=role.role_id, related_id=user.user_id)
-    assert rbac.role.member.exists(object_id=role.role_id, related_id=user.user_id)
+    assert Role().owner.exists(object_id=role.role_id, related_id=user.user_id)
+    assert Role().admin.exists(object_id=role.role_id, related_id=user.user_id)
+    assert Role().member.exists(object_id=role.role_id, related_id=user.user_id)

--- a/tests/rbac/common/role/propose_admin_helper.py
+++ b/tests/rbac/common/role/propose_admin_helper.py
@@ -16,7 +16,8 @@
 # pylint: disable=no-member,too-few-public-methods
 import random
 
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.role import Role
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common.user.create_user_helper import CreateUserTestHelper
@@ -43,7 +44,7 @@ class ProposeRoleAdminTestHelper:
 
     def id(self):
         """Get a unique identifier"""
-        return rbac.addresser.proposal.unique_id()
+        return addresser.proposal.unique_id()
 
     def reason(self):
         """Get a random reason"""
@@ -56,7 +57,7 @@ class ProposeRoleAdminTestHelper:
         user, user_key = helper.user.create()
         proposal_id = self.id()
         reason = self.reason()
-        message = rbac.role.admin.propose.make(
+        message = Role().admin.propose.make(
             proposal_id=proposal_id,
             role_id=role.role_id,
             user_id=user.user_id,
@@ -64,14 +65,14 @@ class ProposeRoleAdminTestHelper:
             metadata=None,
         )
 
-        status = rbac.role.admin.propose.new(
+        status = Role().admin.propose.new(
             signer_keypair=user_key, signer_user_id=user.user_id, message=message
         )
 
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
-        proposal = rbac.role.admin.propose.get(
+        proposal = Role().admin.propose.get(
             object_id=role.role_id, related_id=user.user_id
         )
 

--- a/tests/rbac/common/role/propose_admin_test.py
+++ b/tests/rbac/common/role/propose_admin_test.py
@@ -18,7 +18,9 @@
 
 import pytest
 
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.role import Role
+from rbac.common.user import User
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -33,9 +35,9 @@ def test_make():
     """Test making the message"""
     user_id = helper.user.id()
     role_id = helper.role.id()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.proposal.reason()
-    message = rbac.role.admin.propose.make(
+    message = Role().admin.propose.make(
         proposal_id=proposal_id,
         user_id=user_id,
         role_id=role_id,
@@ -54,15 +56,15 @@ def test_make():
 def test_make_addresses():
     """Test making the message addresses"""
     user_id = helper.user.id()
-    user_address = rbac.user.address(user_id)
+    user_address = User().address(user_id)
     role_id = helper.role.id()
-    role_address = rbac.role.address(role_id)
-    proposal_id = rbac.addresser.proposal.unique_id()
+    role_address = Role().address(role_id)
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.proposal.reason()
-    relationship_address = rbac.role.admin.address(role_id, user_id)
-    proposal_address = rbac.role.admin.propose.address(role_id, user_id)
+    relationship_address = Role().admin.address(role_id, user_id)
+    proposal_address = Role().admin.propose.address(role_id, user_id)
     signer_user_id = helper.user.id()
-    message = rbac.role.admin.propose.make(
+    message = Role().admin.propose.make(
         proposal_id=proposal_id,
         user_id=user_id,
         role_id=role_id,
@@ -70,7 +72,7 @@ def test_make_addresses():
         metadata=None,
     )
 
-    inputs, outputs = rbac.role.admin.propose.make_addresses(
+    inputs, outputs = Role().admin.propose.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -87,11 +89,11 @@ def test_make_addresses():
 def test_create():
     """Test executing the message on the blockchain"""
     role, _, _ = helper.role.create()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.proposal.reason()
     user, signer_keypair = helper.user.create()
 
-    message = rbac.role.admin.propose.make(
+    message = Role().admin.propose.make(
         proposal_id=proposal_id,
         user_id=user.user_id,
         role_id=role.role_id,
@@ -99,16 +101,14 @@ def test_create():
         metadata=None,
     )
 
-    status = rbac.role.admin.propose.new(
+    status = Role().admin.propose.new(
         signer_keypair=signer_keypair, signer_user_id=user.user_id, message=message
     )
 
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    proposal = rbac.role.admin.propose.get(
-        object_id=role.role_id, related_id=user.user_id
-    )
+    proposal = Role().admin.propose.get(object_id=role.role_id, related_id=user.user_id)
 
     assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
     assert proposal.proposal_type, protobuf.proposal_state_pb2.Proposal.ADD_ROLE_ADMIN

--- a/tests/rbac/common/role/propose_member_helper.py
+++ b/tests/rbac/common/role/propose_member_helper.py
@@ -16,7 +16,8 @@
 # pylint: disable=no-member,too-few-public-methods
 import random
 
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.role import Role
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common.user.create_user_helper import CreateUserTestHelper
@@ -43,7 +44,7 @@ class ProposeRoleMemberTestHelper:
 
     def id(self):
         """Get a unique identifier"""
-        return rbac.addresser.proposal.unique_id()
+        return addresser.proposal.unique_id()
 
     def reason(self):
         """Get a random reason"""
@@ -56,7 +57,7 @@ class ProposeRoleMemberTestHelper:
         user, user_key = helper.user.create()
         proposal_id = self.id()
         reason = self.reason()
-        message = rbac.role.member.propose.make(
+        message = Role().member.propose.make(
             proposal_id=proposal_id,
             role_id=role.role_id,
             user_id=user.user_id,
@@ -64,14 +65,14 @@ class ProposeRoleMemberTestHelper:
             metadata=None,
         )
 
-        status = rbac.role.member.propose.new(
+        status = Role().member.propose.new(
             signer_keypair=user_key, signer_user_id=user.user_id, message=message
         )
 
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
-        proposal = rbac.role.member.propose.get(
+        proposal = Role().member.propose.get(
             object_id=role.role_id, related_id=user.user_id
         )
 

--- a/tests/rbac/common/role/propose_member_test.py
+++ b/tests/rbac/common/role/propose_member_test.py
@@ -16,7 +16,9 @@
 # pylint: disable=no-member
 import pytest
 
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.user import User
+from rbac.common.role import Role
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -31,9 +33,9 @@ def test_make():
     """Test making the message"""
     user_id = helper.user.id()
     role_id = helper.role.id()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.proposal.reason()
-    message = rbac.role.member.propose.make(
+    message = Role().member.propose.make(
         proposal_id=proposal_id,
         user_id=user_id,
         role_id=role_id,
@@ -52,15 +54,15 @@ def test_make():
 def test_make_addresses():
     """Test making the message addresses"""
     user_id = helper.user.id()
-    user_address = rbac.user.address(user_id)
+    user_address = User().address(user_id)
     role_id = helper.role.id()
-    role_address = rbac.role.address(role_id)
-    proposal_id = rbac.addresser.proposal.unique_id()
+    role_address = Role().address(role_id)
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.proposal.reason()
-    relationship_address = rbac.role.member.address(role_id, user_id)
-    proposal_address = rbac.role.member.propose.address(role_id, user_id)
+    relationship_address = Role().member.address(role_id, user_id)
+    proposal_address = Role().member.propose.address(role_id, user_id)
     signer_user_id = helper.user.id()
-    message = rbac.role.member.propose.make(
+    message = Role().member.propose.make(
         proposal_id=proposal_id,
         user_id=user_id,
         role_id=role_id,
@@ -68,7 +70,7 @@ def test_make_addresses():
         metadata=None,
     )
 
-    inputs, outputs = rbac.role.member.propose.make_addresses(
+    inputs, outputs = Role().member.propose.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -85,11 +87,11 @@ def test_make_addresses():
 def test_create():
     """Test executing the message on the blockchain"""
     role, _, _ = helper.role.create()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.proposal.reason()
     user, signer_keypair = helper.user.create()
 
-    message = rbac.role.member.propose.make(
+    message = Role().member.propose.make(
         proposal_id=proposal_id,
         user_id=user.user_id,
         role_id=role.role_id,
@@ -98,14 +100,14 @@ def test_create():
         signer_user_id=user.user_id,
     )
 
-    status = rbac.role.member.propose.new(
+    status = Role().member.propose.new(
         signer_keypair=signer_keypair, signer_user_id=user.user_id, message=message
     )
 
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    proposal = rbac.role.member.propose.get(
+    proposal = Role().member.propose.get(
         object_id=role.role_id, related_id=user.user_id
     )
 

--- a/tests/rbac/common/role/propose_owner_helper.py
+++ b/tests/rbac/common/role/propose_owner_helper.py
@@ -16,7 +16,8 @@
 # pylint: disable=no-member,too-few-public-methods
 import random
 
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.role import Role
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common.user.create_user_helper import CreateUserTestHelper
@@ -42,7 +43,7 @@ class ProposeRoleOwnerTestHelper:
 
     def id(self):
         """Get a unique identifier"""
-        return rbac.addresser.proposal.unique_id()
+        return addresser.proposal.unique_id()
 
     def reason(self):
         """Get a random reason"""
@@ -55,7 +56,7 @@ class ProposeRoleOwnerTestHelper:
         user, user_key = helper.user.create()
         proposal_id = self.id()
         reason = helper.user.reason()
-        message = rbac.role.owner.propose.make(
+        message = Role().owner.propose.make(
             proposal_id=proposal_id,
             role_id=role.role_id,
             user_id=user.user_id,
@@ -63,14 +64,14 @@ class ProposeRoleOwnerTestHelper:
             metadata=None,
         )
 
-        status = rbac.role.owner.propose.new(
+        status = Role().owner.propose.new(
             signer_keypair=user_key, signer_user_id=user.user_id, message=message
         )
 
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
-        proposal = rbac.role.owner.propose.get(
+        proposal = Role().owner.propose.get(
             object_id=role.role_id, related_id=user.user_id
         )
 

--- a/tests/rbac/common/role/propose_owner_test.py
+++ b/tests/rbac/common/role/propose_owner_test.py
@@ -16,7 +16,9 @@
 # pylint: disable=no-member
 import pytest
 
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.role import Role
+from rbac.common.user import User
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -30,9 +32,9 @@ def test_make():
     """Test making the message"""
     user_id = helper.user.id()
     role_id = helper.role.id()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.proposal.reason()
-    message = rbac.role.owner.propose.make(
+    message = Role().owner.propose.make(
         proposal_id=proposal_id,
         user_id=user_id,
         role_id=role_id,
@@ -51,15 +53,15 @@ def test_make():
 def test_make_addresses():
     """Test making the message addresses"""
     user_id = helper.user.id()
-    user_address = rbac.user.address(user_id)
+    user_address = User().address(user_id)
     role_id = helper.role.id()
-    role_address = rbac.role.address(role_id)
-    proposal_id = rbac.addresser.proposal.unique_id()
+    role_address = Role().address(role_id)
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.proposal.reason()
-    relationship_address = rbac.role.owner.address(role_id, user_id)
-    proposal_address = rbac.role.owner.propose.address(role_id, user_id)
+    relationship_address = Role().owner.address(role_id, user_id)
+    proposal_address = Role().owner.propose.address(role_id, user_id)
     signer_user_id = helper.user.id()
-    message = rbac.role.owner.propose.make(
+    message = Role().owner.propose.make(
         proposal_id=proposal_id,
         user_id=user_id,
         role_id=role_id,
@@ -67,7 +69,7 @@ def test_make_addresses():
         metadata=None,
     )
 
-    inputs, outputs = rbac.role.owner.propose.make_addresses(
+    inputs, outputs = Role().owner.propose.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -84,11 +86,11 @@ def test_make_addresses():
 def test_create():
     """Test executing the message on the blockchain"""
     role, _, _ = helper.role.create()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.proposal.reason()
     user, signer_keypair = helper.user.create()
 
-    message = rbac.role.owner.propose.make(
+    message = Role().owner.propose.make(
         proposal_id=proposal_id,
         user_id=user.user_id,
         role_id=role.role_id,
@@ -96,16 +98,14 @@ def test_create():
         metadata=None,
     )
 
-    status = rbac.role.owner.propose.new(
+    status = Role().owner.propose.new(
         signer_keypair=signer_keypair, signer_user_id=user.user_id, message=message
     )
 
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    proposal = rbac.role.owner.propose.get(
-        object_id=role.role_id, related_id=user.user_id
-    )
+    proposal = Role().owner.propose.get(object_id=role.role_id, related_id=user.user_id)
 
     assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
     assert proposal.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_ROLE_OWNER

--- a/tests/rbac/common/role/propose_task_helper.py
+++ b/tests/rbac/common/role/propose_task_helper.py
@@ -16,7 +16,8 @@
 # pylint: disable=no-member,too-few-public-methods
 import random
 
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.role import Role
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common.task.create_task_helper import CreateTaskTestHelper
@@ -42,7 +43,7 @@ class ProposeRoleTaskTestHelper:
 
     def id(self):
         """Get a unique identifier"""
-        return rbac.addresser.proposal.unique_id()
+        return addresser.proposal.unique_id()
 
     def reason(self):
         """Get a random reason"""
@@ -55,7 +56,7 @@ class ProposeRoleTaskTestHelper:
         task, task_owner, task_owner_key = helper.task.create()
         proposal_id = self.id()
         reason = self.reason()
-        message = rbac.role.task.propose.make(
+        message = Role().task.propose.make(
             proposal_id=proposal_id,
             role_id=role.role_id,
             task_id=task.task_id,
@@ -63,7 +64,7 @@ class ProposeRoleTaskTestHelper:
             metadata=None,
         )
 
-        status = rbac.role.task.propose.new(
+        status = Role().task.propose.new(
             signer_keypair=role_owner_key,
             signer_user_id=role_owner.user_id,
             message=message,
@@ -72,7 +73,7 @@ class ProposeRoleTaskTestHelper:
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
-        proposal = rbac.role.task.propose.get(
+        proposal = Role().task.propose.get(
             object_id=role.role_id, related_id=task.task_id
         )
 

--- a/tests/rbac/common/role/propose_task_test.py
+++ b/tests/rbac/common/role/propose_task_test.py
@@ -16,7 +16,9 @@
 # pylint: disable=no-member,too-many-locals
 import pytest
 
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.role import Role
+from rbac.common.task import Task
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -30,9 +32,9 @@ def test_make():
     """Test making the message"""
     task_id = helper.task.id()
     role_id = helper.role.id()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.proposal.reason()
-    message = rbac.role.task.propose.make(
+    message = Role().task.propose.make(
         proposal_id=proposal_id,
         task_id=task_id,
         role_id=role_id,
@@ -51,16 +53,16 @@ def test_make():
 def test_make_addresses():
     """Test making the message addresses"""
     task_id = helper.task.id()
-    task_address = rbac.task.address(task_id)
+    task_address = Task().address(task_id)
     role_id = helper.role.id()
-    role_address = rbac.role.address(role_id)
-    proposal_id = rbac.addresser.proposal.unique_id()
+    role_address = Role().address(role_id)
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.proposal.reason()
-    relationship_address = rbac.role.task.address(role_id, task_id)
-    proposal_address = rbac.role.task.propose.address(role_id, task_id)
+    relationship_address = Role().task.address(role_id, task_id)
+    proposal_address = Role().task.propose.address(role_id, task_id)
     signer_user_id = helper.user.id()
-    role_owner_address = rbac.role.owner.address(role_id, signer_user_id)
-    message = rbac.role.task.propose.make(
+    role_owner_address = Role().owner.address(role_id, signer_user_id)
+    message = Role().task.propose.make(
         proposal_id=proposal_id,
         task_id=task_id,
         role_id=role_id,
@@ -68,7 +70,7 @@ def test_make_addresses():
         metadata=None,
     )
 
-    inputs, outputs = rbac.role.task.propose.make_addresses(
+    inputs, outputs = Role().task.propose.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -86,11 +88,11 @@ def test_make_addresses():
 def test_create():
     """Test executing the message on the blockchain"""
     role, role_owner, role_owner_key = helper.role.create()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.proposal.reason()
     task, _, _ = helper.task.create()
 
-    message = rbac.role.task.propose.make(
+    message = Role().task.propose.make(
         proposal_id=proposal_id,
         task_id=task.task_id,
         role_id=role.role_id,
@@ -98,7 +100,7 @@ def test_create():
         metadata=None,
     )
 
-    status = rbac.role.task.propose.new(
+    status = Role().task.propose.new(
         signer_keypair=role_owner_key,
         signer_user_id=role_owner.user_id,
         message=message,
@@ -107,9 +109,7 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    proposal = rbac.role.task.propose.get(
-        object_id=role.role_id, related_id=task.task_id
-    )
+    proposal = Role().task.propose.get(object_id=role.role_id, related_id=task.task_id)
 
     assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
     assert proposal.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_ROLE_TASK

--- a/tests/rbac/common/role/reject_admin_test.py
+++ b/tests/rbac/common/role/reject_admin_test.py
@@ -16,7 +16,7 @@
 # pylint: disable=no-member
 import pytest
 
-from rbac.common import rbac
+from rbac.common.role import Role
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -32,7 +32,7 @@ def test_make():
     object_id = helper.role.id()
     proposal_id = helper.proposal.id()
     reason = helper.proposal.reason()
-    message = rbac.role.admin.reject.make(
+    message = Role().admin.reject.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
@@ -52,18 +52,18 @@ def test_make_addresses():
     related_id = helper.user.id()
     object_id = helper.role.id()
     proposal_id = helper.proposal.id()
-    proposal_address = rbac.role.admin.propose.address(object_id, related_id)
+    proposal_address = Role().admin.propose.address(object_id, related_id)
     reason = helper.proposal.reason()
     signer_user_id = helper.user.id()
-    signer_admin_address = rbac.role.admin.address(object_id, signer_user_id)
-    message = rbac.role.admin.reject.make(
+    signer_admin_address = Role().admin.address(object_id, signer_user_id)
+    message = Role().admin.reject.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
         reason=reason,
     )
 
-    inputs, outputs = rbac.role.admin.reject.make_addresses(
+    inputs, outputs = Role().admin.reject.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -80,14 +80,14 @@ def test_create():
     proposal, _, role_admin, role_admin_key, _, _ = helper.role.admin.propose.create()
 
     reason = helper.role.admin.propose.reason()
-    message = rbac.role.admin.reject.make(
+    message = Role().admin.reject.make(
         proposal_id=proposal.proposal_id,
         object_id=proposal.object_id,
         related_id=proposal.related_id,
         reason=reason,
     )
 
-    status = rbac.role.admin.reject.new(
+    status = Role().admin.reject.new(
         signer_keypair=role_admin_key,
         signer_user_id=role_admin.user_id,
         message=message,
@@ -96,7 +96,7 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    reject = rbac.role.admin.propose.get(
+    reject = Role().admin.propose.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 

--- a/tests/rbac/common/role/reject_member_test.py
+++ b/tests/rbac/common/role/reject_member_test.py
@@ -16,7 +16,7 @@
 # pylint: disable=no-member
 import pytest
 
-from rbac.common import rbac
+from rbac.common.role import Role
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -32,7 +32,7 @@ def test_make():
     object_id = helper.role.id()
     proposal_id = helper.proposal.id()
     reason = helper.proposal.reason()
-    message = rbac.role.member.reject.make(
+    message = Role().member.reject.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
@@ -52,19 +52,19 @@ def test_make_addresses():
     related_id = helper.user.id()
     object_id = helper.role.id()
     proposal_id = helper.proposal.id()
-    proposal_address = rbac.role.member.propose.address(object_id, related_id)
+    proposal_address = Role().member.propose.address(object_id, related_id)
     reason = helper.proposal.reason()
     signer_user_id = helper.user.id()
-    signer_admin_address = rbac.role.admin.address(object_id, signer_user_id)
-    signer_owner_address = rbac.role.owner.address(object_id, signer_user_id)
-    message = rbac.role.member.reject.make(
+    signer_admin_address = Role().admin.address(object_id, signer_user_id)
+    signer_owner_address = Role().owner.address(object_id, signer_user_id)
+    message = Role().member.reject.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
         reason=reason,
     )
 
-    inputs, outputs = rbac.role.member.reject.make_addresses(
+    inputs, outputs = Role().member.reject.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -82,14 +82,14 @@ def test_create():
     proposal, _, role_owner, role_owner_key, _, _ = helper.role.member.propose.create()
 
     reason = helper.role.member.propose.reason()
-    message = rbac.role.member.reject.make(
+    message = Role().member.reject.make(
         proposal_id=proposal.proposal_id,
         object_id=proposal.object_id,
         related_id=proposal.related_id,
         reason=reason,
     )
 
-    status = rbac.role.member.reject.new(
+    status = Role().member.reject.new(
         signer_keypair=role_owner_key,
         signer_user_id=role_owner.user_id,
         message=message,
@@ -100,7 +100,7 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    reject = rbac.role.member.propose.get(
+    reject = Role().member.propose.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 

--- a/tests/rbac/common/role/reject_owner_test.py
+++ b/tests/rbac/common/role/reject_owner_test.py
@@ -16,7 +16,7 @@
 # pylint: disable=no-member
 import pytest
 
-from rbac.common import rbac
+from rbac.common.role import Role
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -32,7 +32,7 @@ def test_make():
     object_id = helper.role.id()
     proposal_id = helper.proposal.id()
     reason = helper.proposal.reason()
-    message = rbac.role.owner.reject.make(
+    message = Role().owner.reject.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
@@ -52,19 +52,19 @@ def test_make_addresses():
     related_id = helper.user.id()
     object_id = helper.role.id()
     proposal_id = helper.proposal.id()
-    proposal_address = rbac.role.owner.propose.address(object_id, related_id)
+    proposal_address = Role().owner.propose.address(object_id, related_id)
     reason = helper.proposal.reason()
     signer_user_id = helper.user.id()
-    signer_admin_address = rbac.role.admin.address(object_id, signer_user_id)
-    signer_owner_address = rbac.role.owner.address(object_id, signer_user_id)
-    message = rbac.role.owner.reject.make(
+    signer_admin_address = Role().admin.address(object_id, signer_user_id)
+    signer_owner_address = Role().owner.address(object_id, signer_user_id)
+    message = Role().owner.reject.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
         reason=reason,
     )
 
-    inputs, outputs = rbac.role.owner.reject.make_addresses(
+    inputs, outputs = Role().owner.reject.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -82,14 +82,14 @@ def test_create():
     proposal, _, role_owner, role_owner_key, _, _ = helper.role.owner.propose.create()
 
     reason = helper.role.owner.propose.reason()
-    message = rbac.role.owner.reject.make(
+    message = Role().owner.reject.make(
         proposal_id=proposal.proposal_id,
         object_id=proposal.object_id,
         related_id=proposal.related_id,
         reason=reason,
     )
 
-    status = rbac.role.owner.reject.new(
+    status = Role().owner.reject.new(
         signer_keypair=role_owner_key,
         signer_user_id=role_owner.user_id,
         message=message,
@@ -98,7 +98,7 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    reject = rbac.role.owner.propose.get(
+    reject = Role().owner.propose.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 

--- a/tests/rbac/common/role/reject_task_test.py
+++ b/tests/rbac/common/role/reject_task_test.py
@@ -16,7 +16,8 @@
 # pylint: disable=no-member
 import pytest
 
-from rbac.common import rbac
+from rbac.common.role import Role
+from rbac.common.task import Task
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -32,7 +33,7 @@ def test_make():
     object_id = helper.role.id()
     proposal_id = helper.proposal.id()
     reason = helper.proposal.reason()
-    message = rbac.role.task.reject.make(
+    message = Role().task.reject.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
@@ -52,18 +53,18 @@ def test_make_addresses():
     related_id = helper.task.id()
     object_id = helper.role.id()
     proposal_id = helper.proposal.id()
-    proposal_address = rbac.role.task.propose.address(object_id, related_id)
+    proposal_address = Role().task.propose.address(object_id, related_id)
     reason = helper.proposal.reason()
     signer_user_id = helper.user.id()
-    task_owner_address = rbac.task.owner.address(related_id, signer_user_id)
-    message = rbac.role.task.reject.make(
+    task_owner_address = Task().owner.address(related_id, signer_user_id)
+    message = Role().task.reject.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
         reason=reason,
     )
 
-    inputs, outputs = rbac.role.task.reject.make_addresses(
+    inputs, outputs = Role().task.reject.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -80,14 +81,14 @@ def test_create():
     proposal, _, _, _, _, task_owner, task_owner_key = helper.role.task.propose.create()
 
     reason = helper.role.task.propose.reason()
-    message = rbac.role.task.reject.make(
+    message = Role().task.reject.make(
         proposal_id=proposal.proposal_id,
         object_id=proposal.object_id,
         related_id=proposal.related_id,
         reason=reason,
     )
 
-    status = rbac.role.task.reject.new(
+    status = Role().task.reject.new(
         signer_keypair=task_owner_key,
         signer_user_id=task_owner.user_id,
         message=message,
@@ -96,7 +97,7 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    reject = rbac.role.task.propose.get(
+    reject = Role().task.propose.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 

--- a/tests/rbac/common/role/remove_member_test.py
+++ b/tests/rbac/common/role/remove_member_test.py
@@ -17,7 +17,8 @@
 # pylint: disable=no-member
 import pytest
 
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.role import Role
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -34,8 +35,8 @@ def test_make():
     user_id = helper.user.id()
     role_id = helper.role.id()
     reason = helper.proposal.reason()
-    proposal_id = rbac.addresser.proposal.unique_id()
-    message = rbac.role.member.remove.make(
+    proposal_id = addresser.proposal.unique_id()
+    message = Role().member.remove.make(
         proposal_id=proposal_id, object_id=role_id, related_id=user_id, reason=reason
     )
     assert isinstance(message, protobuf.proposal_transaction_pb2.RemovalProposal)
@@ -52,18 +53,18 @@ def test_make_addresses():
     """Test making the message addresses"""
     user_id = helper.user.id()
     role_id = helper.role.id()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.proposal.reason()
     signer_user_id = helper.user.id()
-    relationship_address = rbac.role.member.address(role_id, user_id)
-    proposal_address = rbac.role.member.remove.address(role_id, user_id)
-    role_owner_address = rbac.role.owner.address(role_id, signer_user_id)
+    relationship_address = Role().member.address(role_id, user_id)
+    proposal_address = Role().member.remove.address(role_id, user_id)
+    role_owner_address = Role().owner.address(role_id, signer_user_id)
 
-    message = rbac.role.member.remove.make(
+    message = Role().member.remove.make(
         proposal_id=proposal_id, object_id=role_id, related_id=user_id, reason=reason
     )
 
-    inputs, outputs = rbac.role.member.remove.make_addresses(
+    inputs, outputs = Role().member.remove.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -83,7 +84,7 @@ def test_new():
 
     reason = helper.role.member.propose.reason()
 
-    status = rbac.role.member.confirm.new(
+    status = Role().member.confirm.new(
         signer_keypair=role_owner_key,
         signer_user_id=role_owner.user_id,
         proposal_id=proposal.proposal_id,
@@ -95,18 +96,18 @@ def test_new():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    assert rbac.role.member.exists(
+    assert Role().member.exists(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 
     proposal_id = helper.proposal.id()
     reason = helper.proposal.reason()
 
-    rbac.role.member.confirm.get(
+    Role().member.confirm.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 
-    status2 = rbac.role.member.remove.new(
+    status2 = Role().member.remove.new(
         signer_keypair=role_owner_key,
         signer_user_id=role_owner.user_id,
         proposal_id=proposal_id,
@@ -118,7 +119,7 @@ def test_new():
     assert len(status2) == 1
     assert status2[0]["status"] == "COMMITTED"
 
-    removal = rbac.role.member.remove.get(
+    removal = Role().member.remove.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 
@@ -135,6 +136,6 @@ def test_new():
     assert removal.closer == role_owner.user_id
     assert removal.status == protobuf.proposal_state_pb2.Proposal.REMOVED
 
-    assert rbac.role.member.not_exists(
+    assert Role().member.not_exists(
         object_id=proposal.object_id, related_id=proposal.related_id
     )

--- a/tests/rbac/common/task/confirm_admin_test.py
+++ b/tests/rbac/common/task/confirm_admin_test.py
@@ -17,7 +17,8 @@
 
 import pytest
 
-from rbac.common import rbac
+from rbac.common.user import User
+from rbac.common.task import Task
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -33,7 +34,7 @@ def test_make():
     object_id = helper.task.id()
     proposal_id = helper.proposal.id()
     reason = helper.proposal.reason()
-    message = rbac.task.admin.confirm.make(
+    message = Task().admin.confirm.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
@@ -53,23 +54,23 @@ def test_make_addresses():
     related_id = helper.user.id()
     object_id = helper.task.id()
     proposal_id = helper.proposal.id()
-    proposal_address = rbac.task.admin.propose.address(object_id, related_id)
+    proposal_address = Task().admin.propose.address(object_id, related_id)
     reason = helper.proposal.reason()
-    relationship_address = rbac.task.admin.address(object_id, related_id)
+    relationship_address = Task().admin.address(object_id, related_id)
     signer_user_id = helper.user.id()
     helper.user.key()
 
-    user_address = rbac.user.address(related_id)
-    signer_admin_address = rbac.task.admin.address(object_id, signer_user_id)
-    rbac.user.address(signer_user_id)
-    message = rbac.task.admin.confirm.make(
+    user_address = User().address(related_id)
+    signer_admin_address = Task().admin.address(object_id, signer_user_id)
+    User().address(signer_user_id)
+    message = Task().admin.confirm.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
         reason=reason,
     )
 
-    inputs, outputs = rbac.task.admin.confirm.make_addresses(
+    inputs, outputs = Task().admin.confirm.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -89,14 +90,14 @@ def test_create():
     proposal, _, task_admin, task_admin_key, _, _ = helper.task.admin.propose.create()
 
     reason = helper.task.admin.propose.reason()
-    message = rbac.task.admin.confirm.make(
+    message = Task().admin.confirm.make(
         proposal_id=proposal.proposal_id,
         object_id=proposal.object_id,
         related_id=proposal.related_id,
         reason=reason,
     )
 
-    status = rbac.task.admin.confirm.new(
+    status = Task().admin.confirm.new(
         signer_keypair=task_admin_key,
         signer_user_id=task_admin.user_id,
         message=message,
@@ -105,7 +106,7 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    confirm = rbac.task.admin.confirm.get(
+    confirm = Task().admin.confirm.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 
@@ -117,6 +118,6 @@ def test_create():
     assert confirm.close_reason == reason
     assert confirm.closer == task_admin.user_id
     assert confirm.status == protobuf.proposal_state_pb2.Proposal.CONFIRMED
-    assert rbac.task.admin.exists(
+    assert Task().admin.exists(
         object_id=proposal.object_id, related_id=proposal.related_id
     )

--- a/tests/rbac/common/task/confirm_owner_test.py
+++ b/tests/rbac/common/task/confirm_owner_test.py
@@ -17,7 +17,8 @@
 
 import pytest
 
-from rbac.common import rbac
+from rbac.common.user import User
+from rbac.common.task import Task
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -33,7 +34,7 @@ def test_make():
     object_id = helper.task.id()
     proposal_id = helper.proposal.id()
     reason = helper.proposal.reason()
-    message = rbac.task.owner.confirm.make(
+    message = Task().owner.confirm.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
@@ -53,23 +54,23 @@ def test_make_addresses():
     related_id = helper.user.id()
     object_id = helper.task.id()
     proposal_id = helper.proposal.id()
-    proposal_address = rbac.task.owner.propose.address(object_id, related_id)
+    proposal_address = Task().owner.propose.address(object_id, related_id)
     reason = helper.proposal.reason()
-    relationship_address = rbac.task.owner.address(object_id, related_id)
+    relationship_address = Task().owner.address(object_id, related_id)
     signer_user_id = helper.user.id()
     helper.user.key()
 
-    user_address = rbac.user.address(related_id)
-    signer_admin_address = rbac.task.admin.address(object_id, signer_user_id)
-    signer_owner_address = rbac.task.owner.address(object_id, signer_user_id)
-    message = rbac.task.owner.confirm.make(
+    user_address = User().address(related_id)
+    signer_admin_address = Task().admin.address(object_id, signer_user_id)
+    signer_owner_address = Task().owner.address(object_id, signer_user_id)
+    message = Task().owner.confirm.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
         reason=reason,
     )
 
-    inputs, outputs = rbac.task.owner.confirm.make_addresses(
+    inputs, outputs = Task().owner.confirm.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -90,14 +91,14 @@ def test_create():
     proposal, _, task_owner, task_owner_key, _, _ = helper.task.owner.propose.create()
 
     reason = helper.task.owner.propose.reason()
-    message = rbac.task.owner.confirm.make(
+    message = Task().owner.confirm.make(
         proposal_id=proposal.proposal_id,
         object_id=proposal.object_id,
         related_id=proposal.related_id,
         reason=reason,
     )
 
-    status = rbac.task.owner.confirm.new(
+    status = Task().owner.confirm.new(
         signer_keypair=task_owner_key,
         signer_user_id=task_owner.user_id,
         message=message,
@@ -106,7 +107,7 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    confirm = rbac.task.owner.confirm.get(
+    confirm = Task().owner.confirm.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 
@@ -118,6 +119,6 @@ def test_create():
     assert confirm.close_reason == reason
     assert confirm.closer == task_owner.user_id
     assert confirm.status == protobuf.proposal_state_pb2.Proposal.CONFIRMED
-    assert rbac.task.owner.exists(
+    assert Task().owner.exists(
         object_id=proposal.object_id, related_id=proposal.related_id
     )

--- a/tests/rbac/common/task/create_task_helper.py
+++ b/tests/rbac/common/task/create_task_helper.py
@@ -17,7 +17,8 @@
 
 import random
 
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.task import Task
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common.user.create_user_helper import CreateUserTestHelper
@@ -41,7 +42,7 @@ class CreateTaskTestHelper:
 
     def id(self):
         """Get a test task_id (not created)"""
-        return rbac.addresser.task.unique_id()
+        return addresser.task.unique_id()
 
     def name(self):
         """Get a random name"""
@@ -56,7 +57,7 @@ class CreateTaskTestHelper:
         task_id = self.id()
         name = self.name()
         user_id = helper.user.id()
-        message = rbac.task.make(
+        message = Task().make(
             task_id=task_id, name=name, owners=[user_id], admins=[user_id]
         )
         assert isinstance(message, protobuf.task_transaction_pb2.CreateTask)
@@ -69,21 +70,21 @@ class CreateTaskTestHelper:
         task_id = self.id()
         name = self.name()
         user, keypair = helper.user.create()
-        message = rbac.task.make(
+        message = Task().make(
             task_id=task_id, name=name, owners=[user.user_id], admins=[user.user_id]
         )
 
-        status = rbac.task.new(
+        status = Task().new(
             signer_keypair=keypair, signer_user_id=user.user_id, message=message
         )
 
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
-        task = rbac.task.get(object_id=message.task_id)
+        task = Task().get(object_id=message.task_id)
 
         assert task.task_id == message.task_id
         assert task.name == message.name
-        assert rbac.task.owner.exists(object_id=task.task_id, related_id=user.user_id)
-        assert rbac.task.admin.exists(object_id=task.task_id, related_id=user.user_id)
+        assert Task().owner.exists(object_id=task.task_id, related_id=user.user_id)
+        assert Task().admin.exists(object_id=task.task_id, related_id=user.user_id)
         return task, user, keypair

--- a/tests/rbac/common/task/propose_admin_helper.py
+++ b/tests/rbac/common/task/propose_admin_helper.py
@@ -17,7 +17,8 @@
 
 import random
 
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.task import Task
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common.user.create_user_helper import CreateUserTestHelper
@@ -43,7 +44,7 @@ class ProposeTaskAdminTestHelper:
 
     def id(self):
         """Get a unique identifier"""
-        return rbac.addresser.proposal.unique_id()
+        return addresser.proposal.unique_id()
 
     def reason(self):
         """Get a random reason"""
@@ -56,7 +57,7 @@ class ProposeTaskAdminTestHelper:
         user, user_key = helper.user.create()
         proposal_id = self.id()
         reason = self.reason()
-        message = rbac.task.admin.propose.make(
+        message = Task().admin.propose.make(
             proposal_id=proposal_id,
             task_id=task.task_id,
             user_id=user.user_id,
@@ -64,7 +65,7 @@ class ProposeTaskAdminTestHelper:
             metadata=None,
         )
 
-        status = rbac.task.admin.propose.new(
+        status = Task().admin.propose.new(
             signer_keypair=user_key,
             signer_user_id=user.user_id,
             message=message,
@@ -75,7 +76,7 @@ class ProposeTaskAdminTestHelper:
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
-        proposal = rbac.task.admin.propose.get(
+        proposal = Task().admin.propose.get(
             object_id=task.task_id, related_id=user.user_id
         )
 

--- a/tests/rbac/common/task/propose_owner_helper.py
+++ b/tests/rbac/common/task/propose_owner_helper.py
@@ -16,7 +16,8 @@
 # pylint: disable=no-member,too-few-public-methods
 import random
 
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.task import Task
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common.user.create_user_helper import CreateUserTestHelper
@@ -42,7 +43,7 @@ class ProposeTaskOwnerTestHelper:
 
     def id(self):
         """Gets a unique identifier"""
-        return rbac.addresser.proposal.unique_id()
+        return addresser.proposal.unique_id()
 
     def reason(self):
         """Get a random reason"""
@@ -55,7 +56,7 @@ class ProposeTaskOwnerTestHelper:
         user, user_key = helper.user.create()
         proposal_id = self.id()
         reason = self.reason()
-        message = rbac.task.owner.propose.make(
+        message = Task().owner.propose.make(
             proposal_id=proposal_id,
             task_id=task.task_id,
             user_id=user.user_id,
@@ -63,7 +64,7 @@ class ProposeTaskOwnerTestHelper:
             metadata=None,
         )
 
-        status = rbac.task.owner.propose.new(
+        status = Task().owner.propose.new(
             signer_keypair=user_key,
             signer_user_id=user.user_id,
             message=message,
@@ -74,7 +75,7 @@ class ProposeTaskOwnerTestHelper:
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
-        proposal = rbac.task.owner.propose.get(
+        proposal = Task().owner.propose.get(
             object_id=task.task_id, related_id=user.user_id
         )
 

--- a/tests/rbac/common/task/propose_owner_test.py
+++ b/tests/rbac/common/task/propose_owner_test.py
@@ -16,7 +16,9 @@
 # pylint: disable=no-member
 import pytest
 
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.user import User
+from rbac.common.task import Task
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -30,9 +32,9 @@ def test_make():
     """Test making the message"""
     user_id = helper.user.id()
     task_id = helper.task.id()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.proposal.reason()
-    message = rbac.task.owner.propose.make(
+    message = Task().owner.propose.make(
         proposal_id=proposal_id,
         user_id=user_id,
         task_id=task_id,
@@ -51,15 +53,15 @@ def test_make():
 def test_make_addresses():
     """Test making the message addresses"""
     user_id = helper.user.id()
-    user_address = rbac.user.address(user_id)
+    user_address = User().address(user_id)
     task_id = helper.task.id()
-    task_address = rbac.task.address(task_id)
-    proposal_id = rbac.addresser.proposal.unique_id()
+    task_address = Task().address(task_id)
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.proposal.reason()
-    relationship_address = rbac.task.owner.address(task_id, user_id)
-    proposal_address = rbac.task.owner.propose.address(task_id, user_id)
+    relationship_address = Task().owner.address(task_id, user_id)
+    proposal_address = Task().owner.propose.address(task_id, user_id)
     signer_user_id = helper.user.id()
-    message = rbac.task.owner.propose.make(
+    message = Task().owner.propose.make(
         proposal_id=proposal_id,
         user_id=user_id,
         task_id=task_id,
@@ -67,7 +69,7 @@ def test_make_addresses():
         metadata=None,
     )
 
-    inputs, outputs = rbac.task.owner.propose.make_addresses(
+    inputs, outputs = Task().owner.propose.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -84,11 +86,11 @@ def test_make_addresses():
 def test_create():
     """Test executing the message on the blockchain"""
     task, _, _ = helper.task.create()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.proposal.reason()
     user, signer_keypair = helper.user.create()
 
-    message = rbac.task.owner.propose.make(
+    message = Task().owner.propose.make(
         proposal_id=proposal_id,
         user_id=user.user_id,
         task_id=task.task_id,
@@ -96,7 +98,7 @@ def test_create():
         metadata=None,
     )
 
-    status = rbac.task.owner.propose.new(
+    status = Task().owner.propose.new(
         signer_keypair=signer_keypair,
         signer_user_id=user.user_id,
         message=message,
@@ -107,9 +109,7 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    proposal = rbac.task.owner.propose.get(
-        object_id=task.task_id, related_id=user.user_id
-    )
+    proposal = Task().owner.propose.get(object_id=task.task_id, related_id=user.user_id)
 
     assert isinstance(proposal, protobuf.proposal_state_pb2.Proposal)
     assert proposal.proposal_type == protobuf.proposal_state_pb2.Proposal.ADD_TASK_OWNER

--- a/tests/rbac/common/task/reject_admin_test.py
+++ b/tests/rbac/common/task/reject_admin_test.py
@@ -16,7 +16,7 @@
 # pylint: disable=no-member
 import pytest
 
-from rbac.common import rbac
+from rbac.common.task import Task
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -32,7 +32,7 @@ def test_make():
     object_id = helper.task.id()
     proposal_id = helper.proposal.id()
     reason = helper.proposal.reason()
-    message = rbac.task.admin.reject.make(
+    message = Task().admin.reject.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
@@ -52,19 +52,19 @@ def test_make_addresses():
     related_id = helper.user.id()
     object_id = helper.task.id()
     proposal_id = helper.proposal.id()
-    proposal_address = rbac.task.admin.propose.address(object_id, related_id)
+    proposal_address = Task().admin.propose.address(object_id, related_id)
     reason = helper.proposal.reason()
     signer_user_id = helper.user.id()
-    signer_admin_address = rbac.task.admin.address(object_id, signer_user_id)
+    signer_admin_address = Task().admin.address(object_id, signer_user_id)
 
-    message = rbac.task.admin.reject.make(
+    message = Task().admin.reject.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
         reason=reason,
     )
 
-    inputs, outputs = rbac.task.admin.reject.make_addresses(
+    inputs, outputs = Task().admin.reject.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -81,14 +81,14 @@ def test_create():
     proposal, _, task_admin, task_admin_key, _, _ = helper.task.admin.propose.create()
 
     reason = helper.task.admin.propose.reason()
-    message = rbac.task.admin.reject.make(
+    message = Task().admin.reject.make(
         proposal_id=proposal.proposal_id,
         object_id=proposal.object_id,
         related_id=proposal.related_id,
         reason=reason,
     )
 
-    status = rbac.task.admin.reject.new(
+    status = Task().admin.reject.new(
         signer_keypair=task_admin_key,
         signer_user_id=task_admin.user_id,
         message=message,
@@ -99,7 +99,7 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    reject = rbac.task.admin.propose.get(
+    reject = Task().admin.propose.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 

--- a/tests/rbac/common/task/reject_owner_test.py
+++ b/tests/rbac/common/task/reject_owner_test.py
@@ -16,7 +16,7 @@
 # pylint: disable=no-member
 import pytest
 
-from rbac.common import rbac
+from rbac.common.task import Task
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -32,7 +32,7 @@ def test_make():
     object_id = helper.task.id()
     proposal_id = helper.proposal.id()
     reason = helper.proposal.reason()
-    message = rbac.task.owner.reject.make(
+    message = Task().owner.reject.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
@@ -52,19 +52,19 @@ def test_make_addresses():
     related_id = helper.user.id()
     object_id = helper.task.id()
     proposal_id = helper.proposal.id()
-    proposal_address = rbac.task.owner.propose.address(object_id, related_id)
+    proposal_address = Task().owner.propose.address(object_id, related_id)
     reason = helper.proposal.reason()
     signer_user_id = helper.user.id()
-    signer_admin_address = rbac.task.admin.address(object_id, signer_user_id)
-    signer_owner_address = rbac.task.owner.address(object_id, signer_user_id)
-    message = rbac.task.owner.reject.make(
+    signer_admin_address = Task().admin.address(object_id, signer_user_id)
+    signer_owner_address = Task().owner.address(object_id, signer_user_id)
+    message = Task().owner.reject.make(
         proposal_id=proposal_id,
         related_id=related_id,
         object_id=object_id,
         reason=reason,
     )
 
-    inputs, outputs = rbac.task.owner.reject.make_addresses(
+    inputs, outputs = Task().owner.reject.make_addresses(
         message=message, signer_user_id=signer_user_id
     )
 
@@ -82,14 +82,14 @@ def test_create():
     proposal, _, task_owner, task_owner_key, _, _ = helper.task.owner.propose.create()
 
     reason = helper.task.owner.propose.reason()
-    message = rbac.task.owner.reject.make(
+    message = Task().owner.reject.make(
         proposal_id=proposal.proposal_id,
         object_id=proposal.object_id,
         related_id=proposal.related_id,
         reason=reason,
     )
 
-    status = rbac.task.owner.reject.new(
+    status = Task().owner.reject.new(
         signer_keypair=task_owner_key,
         signer_user_id=task_owner.user_id,
         message=message,
@@ -100,7 +100,7 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    reject = rbac.task.admin.propose.get(
+    reject = Task().admin.propose.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 

--- a/tests/rbac/common/user/confirm_manager_good_test.py
+++ b/tests/rbac/common/user/confirm_manager_good_test.py
@@ -16,7 +16,7 @@
 # pylint: disable=no-member
 import pytest
 
-from rbac.common import rbac
+from rbac.common.user import User
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -32,7 +32,7 @@ def test_make():
     related_id = helper.user.id()
     reason = helper.user.manager.propose.reason()
     proposal_id = helper.user.manager.propose.id()
-    message = rbac.user.manager.confirm.make(
+    message = User().manager.confirm.make(
         proposal_id=proposal_id,
         object_id=object_id,
         related_id=related_id,
@@ -50,21 +50,21 @@ def test_make():
 def test_make_addresses():
     """Test making the message addresses"""
     object_id = helper.user.id()
-    user_address = rbac.user.address(object_id=object_id)
+    user_address = User().address(object_id=object_id)
     related_id = helper.user.id()
     reason = helper.user.manager.propose.reason()
     proposal_id = helper.proposal.id()
-    proposal_address = rbac.user.manager.confirm.address(
+    proposal_address = User().manager.confirm.address(
         object_id=object_id, related_id=related_id
     )
-    message = rbac.user.manager.confirm.make(
+    message = User().manager.confirm.make(
         proposal_id=proposal_id,
         object_id=object_id,
         related_id=related_id,
         reason=reason,
     )
 
-    inputs, outputs = rbac.user.manager.confirm.make_addresses(
+    inputs, outputs = User().manager.confirm.make_addresses(
         message=message, signer_user_id=object_id
     )
 
@@ -82,7 +82,7 @@ def test_create():
     proposal, _, _, manager, manager_key = helper.user.manager.propose.create()
     reason = helper.user.manager.propose.reason()
 
-    status = rbac.user.manager.confirm.new(
+    status = User().manager.confirm.new(
         signer_user_id=manager.user_id,
         signer_keypair=manager_key,
         proposal_id=proposal.proposal_id,
@@ -94,7 +94,7 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    confirm = rbac.user.manager.confirm.get(
+    confirm = User().manager.confirm.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 
@@ -109,6 +109,6 @@ def test_create():
     assert confirm.close_reason == reason
     assert confirm.status == protobuf.proposal_state_pb2.Proposal.CONFIRMED
 
-    user = rbac.user.get(object_id=proposal.object_id)
+    user = User().get(object_id=proposal.object_id)
     assert isinstance(user, protobuf.user_state_pb2.User)
     assert user.manager_id == proposal.related_id

--- a/tests/rbac/common/user/create_user_bad_test.py
+++ b/tests/rbac/common/user/create_user_bad_test.py
@@ -16,7 +16,7 @@
 # pylint: disable=no-member,invalid-name
 import pytest
 
-from rbac.common import rbac
+from rbac.common.user import User
 from rbac.common import protobuf
 from rbac.common.sawtooth import batcher
 from rbac.common.logs import get_default_logger
@@ -34,7 +34,7 @@ def test_make_with_self_manager():
     name = helper.user.name()
 
     with pytest.raises(ValueError):
-        rbac.user.new(
+        User().new(
             signer_user_id=user_id,
             signer_keypair=user_key,
             user_id=user_id,
@@ -55,17 +55,17 @@ def test_with_self_manager():
     message = protobuf.user_transaction_pb2.CreateUser(
         user_id=user_id, name=name, metadata=None, manager_id=user_id
     )
-    inputs, outputs = rbac.user.make_addresses(message=message, signer_user_id=user_id)
+    inputs, outputs = User().make_addresses(message=message, signer_user_id=user_id)
     payload = batcher.make_payload(
         message=message,
-        message_type=rbac.user.message_type,
+        message_type=User().message_type,
         inputs=inputs,
         outputs=outputs,
         signer_user_id=user_id,
         signer_public_key=user_key.public_key,
     )
 
-    status = rbac.user.send(signer_keypair=user_key, payload=payload)
+    status = User().send(signer_keypair=user_key, payload=payload)
 
     assert len(status) == 1
     assert status[0]["status"] == "INVALID"
@@ -84,17 +84,17 @@ def test_with_manager_not_in_state():
     message = protobuf.user_transaction_pb2.CreateUser(
         user_id=user_id, name=name, metadata=None, manager_id=manager_id
     )
-    inputs, outputs = rbac.user.make_addresses(message=message, signer_user_id=user_id)
+    inputs, outputs = User().make_addresses(message=message, signer_user_id=user_id)
     payload = batcher.make_payload(
         message=message,
-        message_type=rbac.user.message_type,
+        message_type=User().message_type,
         inputs=inputs,
         outputs=outputs,
         signer_user_id=user_id,
         signer_public_key=user_key.public_key,
     )
 
-    status = rbac.user.send(signer_keypair=user_key, payload=payload)
+    status = User().send(signer_keypair=user_key, payload=payload)
 
     assert len(status) == 1
     assert status[0]["status"] == "INVALID"
@@ -115,10 +115,10 @@ def test_make_payload_with_other_signer():
         user_id=user_id, name=name, metadata=None, manager_id=manager_id
     )
 
-    rbac.user.make_payload(
+    User().make_payload(
         message=message, signer_user_id=user_id, signer_keypair=user_key
     )
-    rbac.user.make_payload(
+    User().make_payload(
         message=message, signer_user_id=manager_id, signer_keypair=manager_key
     )
 
@@ -138,17 +138,17 @@ def test_with_other_signer():
     message = protobuf.user_transaction_pb2.CreateUser(
         user_id=user_id, name=name, metadata=None, manager_id=manager_id
     )
-    inputs, outputs = rbac.user.make_addresses(message=message, signer_user_id=other_id)
+    inputs, outputs = User().make_addresses(message=message, signer_user_id=other_id)
     payload = batcher.make_payload(
         message=message,
-        message_type=rbac.user.message_type,
+        message_type=User().message_type,
         inputs=inputs,
         outputs=outputs,
         signer_user_id=other_id,
         signer_public_key=other_key.public_key,
     )
 
-    status = rbac.user.send(signer_keypair=other_key, payload=payload)
+    status = User().send(signer_keypair=other_key, payload=payload)
 
     assert len(status) == 1
     assert status[0]["status"] == "INVALID"

--- a/tests/rbac/common/user/create_user_helper.py
+++ b/tests/rbac/common/user/create_user_helper.py
@@ -15,7 +15,7 @@
 """Create User Test Helper"""
 # pylint: disable=no-member,too-few-public-methods,invalid-name
 
-from rbac.common import rbac
+from rbac.common.user import User
 from rbac.common import protobuf
 from rbac.common.crypto.keys import Key
 from rbac.common.logs import get_default_logger
@@ -32,7 +32,7 @@ class CreateUserTestHelper(UserTestData):
         user_id = self.id()
         name = self.name()
         keypair = self.key()
-        user = rbac.user.make(user_id=user_id, name=name, key=keypair.public_key)
+        user = User().make(user_id=user_id, name=name, key=keypair.public_key)
         assert isinstance(user, protobuf.user_transaction_pb2.CreateUser)
         assert user.user_id == user_id
         assert user.name == name
@@ -43,7 +43,7 @@ class CreateUserTestHelper(UserTestData):
         """ Get a test data ImportsUser message
         """
         name = self.name()
-        user = rbac.user.imports.make(name=name)
+        user = User().imports.make(name=name)
 
         assert isinstance(user, protobuf.user_transaction_pb2.ImportsUser)
         assert user.name == name
@@ -54,7 +54,7 @@ class CreateUserTestHelper(UserTestData):
         manager, manager_key = self.message()
         user_id = self.id()
         user_key = self.key()
-        user = rbac.user.make(
+        user = User().make(
             user_id=user_id,
             name=self.name(),
             manager_id=manager.user_id,
@@ -67,14 +67,14 @@ class CreateUserTestHelper(UserTestData):
         """Create a test user"""
         message, keypair = self.message()
 
-        status = rbac.user.new(
+        status = User().new(
             signer_user_id=message.user_id, signer_keypair=keypair, message=message
         )
 
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
-        user = rbac.user.get(object_id=message.user_id)
+        user = User().get(object_id=message.user_id)
 
         assert user.user_id == message.user_id
         assert user.name == message.name
@@ -88,7 +88,7 @@ class CreateUserTestHelper(UserTestData):
 
         message = self.imports_message()
 
-        status = rbac.user.imports.new(
+        status = User().imports.new(
             signer_user_id=message.user_id,
             signer_keypair=signer_keypair,
             message=message,
@@ -97,7 +97,7 @@ class CreateUserTestHelper(UserTestData):
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
-        user = rbac.user.get(object_id=message.user_id)
+        user = User().get(object_id=message.user_id)
 
         assert user.user_id == message.user_id
         assert user.name == message.name
@@ -110,7 +110,7 @@ class CreateUserTestHelper(UserTestData):
         message, user_key = self.message()
         message.manager_id = manager.user_id
 
-        status = rbac.user.new(
+        status = User().new(
             signer_user_id=message.manager_id,
             signer_keypair=manager_key,
             message=message,
@@ -119,7 +119,7 @@ class CreateUserTestHelper(UserTestData):
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
-        user = rbac.user.get(object_id=message.user_id)
+        user = User().get(object_id=message.user_id)
 
         assert user.user_id == message.user_id
         assert user.name == message.name
@@ -133,7 +133,7 @@ class CreateUserTestHelper(UserTestData):
         message, manager_key = self.message()
         message.manager_id = grandmgr.user_id
 
-        status = rbac.user.new(
+        status = User().new(
             signer_user_id=grandmgr.user_id,
             signer_keypair=grandmgr_key,
             message=message,
@@ -142,7 +142,7 @@ class CreateUserTestHelper(UserTestData):
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
-        manager = rbac.user.get(object_id=message.user_id)
+        manager = User().get(object_id=message.user_id)
         assert manager.user_id == message.user_id
         assert manager.name == message.name
         assert manager.manager_id == grandmgr.user_id
@@ -150,14 +150,14 @@ class CreateUserTestHelper(UserTestData):
         message, user_key = self.message()
         message.manager_id = manager.user_id
 
-        status = rbac.user.new(
+        status = User().new(
             signer_user_id=manager.user_id, signer_keypair=manager_key, message=message
         )
 
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
-        user = rbac.user.get(object_id=message.user_id)
+        user = User().get(object_id=message.user_id)
 
         assert user.user_id == message.user_id
         assert user.name == message.name

--- a/tests/rbac/common/user/imports_user_test.py
+++ b/tests/rbac/common/user/imports_user_test.py
@@ -16,7 +16,7 @@
 # pylint: disable=no-member,invalid-name
 import pytest
 
-from rbac.common import rbac
+from rbac.common.user import User
 from rbac.common import protobuf
 from rbac.common.sawtooth import batcher
 from rbac.common.logs import get_default_logger
@@ -32,7 +32,7 @@ def test_make():
     """Test making a create user message"""
     user_id = helper.user.id()
     name = helper.user.name()
-    message = rbac.user.imports.make(user_id=user_id, name=name)
+    message = User().imports.make(user_id=user_id, name=name)
     assert isinstance(message, protobuf.user_transaction_pb2.ImportsUser)
     assert isinstance(message.user_id, str)
     assert isinstance(message.name, str)
@@ -47,11 +47,11 @@ def test_make_addresses():
     """Test making addresses"""
     user_id = helper.user.id()
     name = helper.user.name()
-    message = rbac.user.imports.make(user_id=user_id, name=name)
-    inputs, outputs = rbac.user.imports.make_addresses(
+    message = User().imports.make(user_id=user_id, name=name)
+    inputs, outputs = User().imports.make_addresses(
         message=message, signer_user_id=user_id
     )
-    user_address = rbac.user.address(object_id=message.user_id)
+    user_address = User().address(object_id=message.user_id)
     assert isinstance(inputs, set)
     assert isinstance(outputs, set)
 
@@ -68,7 +68,7 @@ def test_batch():
     name = helper.user.name()
     signer_keypair = helper.user.key()
 
-    batch = rbac.user.imports.batch(
+    batch = User().imports.batch(
         signer_user_id=user_id,
         signer_keypair=signer_keypair,
         user_id=user_id,
@@ -89,7 +89,7 @@ def test_imports_user():
     name = helper.user.name()
     signer_keypair = helper.user.key()
 
-    status = rbac.user.imports.new(
+    status = User().imports.new(
         signer_user_id=user_id,
         signer_keypair=signer_keypair,
         user_id=user_id,
@@ -99,7 +99,7 @@ def test_imports_user():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    user = rbac.user.get(object_id=user_id)
+    user = User().get(object_id=user_id)
 
     assert user.user_id == user_id
     assert user.name == name
@@ -115,7 +115,7 @@ def test_create_with_manager():
     manager_id = helper.user.id()
     manager_name = helper.user.name()
 
-    status = rbac.user.imports.new(
+    status = User().imports.new(
         signer_user_id=user_id,
         signer_keypair=signer_keypair,
         user_id=manager_id,
@@ -125,12 +125,12 @@ def test_create_with_manager():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    manager = rbac.user.get(object_id=manager_id)
+    manager = User().get(object_id=manager_id)
 
     assert manager.user_id == manager_id
     assert manager.name == manager_name
 
-    status = rbac.user.imports.new(
+    status = User().imports.new(
         signer_user_id=user_id,
         signer_keypair=signer_keypair,
         user_id=user_id,
@@ -141,7 +141,7 @@ def test_create_with_manager():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    user = rbac.user.get(object_id=user_id)
+    user = User().get(object_id=user_id)
 
     assert user.user_id == user_id
     assert user.name == name
@@ -157,7 +157,7 @@ def test_create_with_manager_not_in_state():
     name = helper.user.name()
     manager_id = helper.user.id()
 
-    status = rbac.user.imports.new(
+    status = User().imports.new(
         signer_user_id=user_id,
         signer_keypair=signer_keypair,
         user_id=user_id,
@@ -168,7 +168,7 @@ def test_create_with_manager_not_in_state():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    user = rbac.user.get(object_id=user_id)
+    user = User().get(object_id=user_id)
 
     assert user.user_id == user_id
     assert user.name == name
@@ -183,7 +183,7 @@ def test_reimport_user():
     name = helper.user.name()
     signer_keypair = helper.user.key()
 
-    status = rbac.user.imports.new(
+    status = User().imports.new(
         signer_user_id=user_id,
         signer_keypair=signer_keypair,
         user_id=user_id,
@@ -193,17 +193,17 @@ def test_reimport_user():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    user = rbac.user.get(object_id=user_id)
+    user = User().get(object_id=user_id)
     assert user.user_id == user_id
     assert user.name == name
 
-    status = rbac.user.imports.new(
+    status = User().imports.new(
         signer_user_id=user_id,
         signer_keypair=signer_keypair,
         user_id=user_id,
         name=name,
     )
 
-    user = rbac.user.get(object_id=user_id)
+    user = User().get(object_id=user_id)
     assert user.user_id == user_id
     assert user.name == name

--- a/tests/rbac/common/user/propose_manager_bad_test.py
+++ b/tests/rbac/common/user/propose_manager_bad_test.py
@@ -16,7 +16,8 @@
 # pylint: disable=no-member,invalid-name
 import pytest
 
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.user import User
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
 
@@ -30,16 +31,16 @@ def test_manager_not_in_state():
     """Propose a manager who is not in state"""
     user, user_key = helper.user.create()
     manager, _ = helper.user.message()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.user.reason()
-    message = rbac.user.manager.propose.make(
+    message = User().manager.propose.make(
         proposal_id=proposal_id,
         user_id=user.user_id,
         new_manager_id=manager.user_id,
         reason=reason,
         metadata=None,
     )
-    status = rbac.user.manager.propose.new(
+    status = User().manager.propose.new(
         signer_user_id=user.user_id, signer_keypair=user_key, message=message
     )
     assert len(status) == 1
@@ -52,9 +53,9 @@ def test_user_not_in_state():
     """Propose for a user who is not in state"""
     user, user_key = helper.user.message()
     manager, _ = helper.user.create()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.user.reason()
-    message = rbac.user.manager.propose.make(
+    message = User().manager.propose.make(
         proposal_id=proposal_id,
         user_id=user.user_id,
         new_manager_id=manager.user_id,
@@ -62,7 +63,7 @@ def test_user_not_in_state():
         metadata=None,
     )
 
-    status = rbac.user.manager.propose.new(
+    status = User().manager.propose.new(
         signer_user_id=user.user_id, signer_keypair=user_key, message=message
     )
 
@@ -75,9 +76,9 @@ def test_user_not_in_state():
 def test_user_proposes_manager_change():
     """User propose a change in their manager"""
     user, user_key, manager, _ = helper.user.create_with_manager()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.user.reason()
-    message = rbac.user.manager.propose.make(
+    message = User().manager.propose.make(
         proposal_id=proposal_id,
         user_id=user.user_id,
         new_manager_id=manager.user_id,
@@ -85,7 +86,7 @@ def test_user_proposes_manager_change():
         metadata=None,
     )
 
-    status = rbac.user.manager.propose.new(
+    status = User().manager.propose.new(
         signer_user_id=user.user_id, signer_keypair=user_key, message=message
     )
 
@@ -99,9 +100,9 @@ def test_another_proposes_manager_change():
     """A proposed change in manager comes from another"""
     user, _, manager, _ = helper.user.create_with_manager()
     other, other_key = helper.user.create()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.user.reason()
-    message = rbac.user.manager.propose.make(
+    message = User().manager.propose.make(
         proposal_id=proposal_id,
         user_id=user.user_id,
         new_manager_id=manager.user_id,
@@ -109,7 +110,7 @@ def test_another_proposes_manager_change():
         metadata=None,
     )
 
-    status = rbac.user.manager.propose.new(
+    status = User().manager.propose.new(
         signer_user_id=other.user_id, signer_keypair=other_key, message=message
     )
 
@@ -124,9 +125,9 @@ def test_other_propose_manager_has_no_manager():
     user, _ = helper.user.create()
     manager, _ = helper.user.create()
     other, other_key = helper.user.create()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.user.reason()
-    message = rbac.user.manager.propose.make(
+    message = User().manager.propose.make(
         proposal_id=proposal_id,
         user_id=user.user_id,
         new_manager_id=manager.user_id,
@@ -134,7 +135,7 @@ def test_other_propose_manager_has_no_manager():
         metadata=None,
     )
 
-    status = rbac.user.manager.propose.new(
+    status = User().manager.propose.new(
         signer_user_id=other.user_id, signer_keypair=other_key, message=message
     )
 
@@ -148,9 +149,9 @@ def test_other_propose_manager_has_no_manager():
 def test_manager_already_is_manager():
     """Propose the already existing manager"""
     user, _, manager, manager_key = helper.user.create_with_manager()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.user.reason()
-    message = rbac.user.manager.propose.make(
+    message = User().manager.propose.make(
         proposal_id=proposal_id,
         user_id=user.user_id,
         new_manager_id=manager.user_id,
@@ -158,7 +159,7 @@ def test_manager_already_is_manager():
         metadata=None,
     )
 
-    status = rbac.user.manager.propose.new(
+    status = User().manager.propose.new(
         signer_user_id=manager.user_id, signer_keypair=manager_key, message=message
     )
 
@@ -172,9 +173,9 @@ def test_manager_already_is_manager():
 def test_proposed_manager_is_self():
     """Propose self as manager"""
     user, _, _, manager_key = helper.user.create_with_manager()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.user.reason()
-    message = rbac.user.manager.propose.make(
+    message = User().manager.propose.make(
         proposal_id=proposal_id,
         user_id=user.user_id,
         new_manager_id=user.user_id,
@@ -182,7 +183,7 @@ def test_proposed_manager_is_self():
         metadata=None,
     )
 
-    status = rbac.user.manager.propose.new(
+    status = User().manager.propose.new(
         signer_user_id=user.user_id, signer_keypair=manager_key, message=message
     )
 
@@ -195,9 +196,9 @@ def test_proposed_manager_is_self():
 def test_proposed_manager_is_already_proposed():
     """Propose with an open proposal for the same manager"""
     proposal, _, _, manager, manager_key = helper.user.manager.propose.create()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.user.reason()
-    message = rbac.user.manager.propose.make(
+    message = User().manager.propose.make(
         proposal_id=proposal_id,
         user_id=proposal.object_id,
         new_manager_id=manager.user_id,
@@ -205,7 +206,7 @@ def test_proposed_manager_is_already_proposed():
         metadata=None,
     )
 
-    status = rbac.user.manager.propose.new(
+    status = User().manager.propose.new(
         signer_user_id=manager.user_id, signer_keypair=manager_key, message=message
     )
 

--- a/tests/rbac/common/user/propose_manager_good_test.py
+++ b/tests/rbac/common/user/propose_manager_good_test.py
@@ -16,8 +16,9 @@
 # pylint: disable=no-member,invalid-name
 import pytest
 
-from rbac.common import rbac
+from rbac.common.user import User
 from rbac.common import protobuf
+from rbac.common import addresser
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
 
@@ -30,9 +31,9 @@ def test_make():
     """Test making the message"""
     user_id = helper.user.id()
     manager_id = helper.user.id()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.user.reason()
-    message = rbac.user.manager.propose.make(
+    message = User().manager.propose.make(
         proposal_id=proposal_id,
         user_id=user_id,
         new_manager_id=manager_id,
@@ -51,15 +52,15 @@ def test_make():
 def test_make_addresses_user():
     """Test making the message addresses with user as signer"""
     user_id = helper.user.id()
-    user_address = rbac.user.address(object_id=user_id)
+    user_address = User().address(object_id=user_id)
     manager_id = helper.user.id()
-    manager_address = rbac.user.address(object_id=manager_id)
-    proposal_address = rbac.user.manager.propose.address(
+    manager_address = User().address(object_id=manager_id)
+    proposal_address = User().manager.propose.address(
         object_id=user_id, related_id=manager_id
     )
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.user.reason()
-    message = rbac.user.manager.propose.make(
+    message = User().manager.propose.make(
         proposal_id=proposal_id,
         user_id=user_id,
         new_manager_id=manager_id,
@@ -67,7 +68,7 @@ def test_make_addresses_user():
         metadata=None,
     )
 
-    inputs, outputs = rbac.user.manager.propose.make_addresses(
+    inputs, outputs = User().manager.propose.make_addresses(
         message=message, signer_user_id=user_id
     )
 
@@ -83,15 +84,15 @@ def test_make_addresses_user():
 def test_make_addresses_manager():
     """Test making the message addresses with manager as signer"""
     user_id = helper.user.id()
-    user_address = rbac.user.address(object_id=user_id)
+    user_address = User().address(object_id=user_id)
     manager_id = helper.user.id()
-    manager_address = rbac.user.address(object_id=manager_id)
-    proposal_address = rbac.user.manager.propose.address(
+    manager_address = User().address(object_id=manager_id)
+    proposal_address = User().manager.propose.address(
         object_id=user_id, related_id=manager_id
     )
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.user.reason()
-    message = rbac.user.manager.propose.make(
+    message = User().manager.propose.make(
         proposal_id=proposal_id,
         user_id=user_id,
         new_manager_id=manager_id,
@@ -99,7 +100,7 @@ def test_make_addresses_manager():
         metadata=None,
     )
 
-    inputs, outputs = rbac.user.manager.propose.make_addresses(
+    inputs, outputs = User().manager.propose.make_addresses(
         message=message, signer_user_id=user_id
     )
 
@@ -115,15 +116,15 @@ def test_make_addresses_manager():
 def test_make_addresses_other():
     """Test making the message addresses with other signer"""
     user_id = helper.user.id()
-    user_address = rbac.user.address(object_id=user_id)
+    user_address = User().address(object_id=user_id)
     manager_id = helper.user.id()
-    manager_address = rbac.user.address(object_id=manager_id)
-    proposal_address = rbac.user.manager.propose.address(
+    manager_address = User().address(object_id=manager_id)
+    proposal_address = User().manager.propose.address(
         object_id=user_id, related_id=manager_id
     )
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.user.reason()
-    message = rbac.user.manager.propose.make(
+    message = User().manager.propose.make(
         proposal_id=proposal_id,
         user_id=user_id,
         new_manager_id=manager_id,
@@ -131,7 +132,7 @@ def test_make_addresses_other():
         metadata=None,
     )
 
-    inputs, outputs = rbac.user.manager.propose.make_addresses(
+    inputs, outputs = User().manager.propose.make_addresses(
         message=message, signer_user_id=user_id
     )
 
@@ -148,10 +149,10 @@ def test_user_propose_manager_has_no_manager():
     """Test proposing a manager for a user without a manager, signed by user"""
     user, user_key = helper.user.create()
     manager, _ = helper.user.create()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.user.reason()
 
-    status = rbac.user.manager.propose.new(
+    status = User().manager.propose.new(
         signer_user_id=user.user_id,
         signer_keypair=user_key,
         proposal_id=proposal_id,
@@ -164,7 +165,7 @@ def test_user_propose_manager_has_no_manager():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    proposal = rbac.user.manager.propose.get(
+    proposal = User().manager.propose.get(
         object_id=user.user_id, related_id=manager.user_id
     )
 
@@ -187,10 +188,10 @@ def test_manager_propose_manager_has_no_manager():
     """Test proposing a manager for a user without a manager, signed by new manager"""
     user, _ = helper.user.create()
     manager, manager_key = helper.user.create()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.user.reason()
 
-    status = rbac.user.manager.propose.new(
+    status = User().manager.propose.new(
         signer_user_id=manager.user_id,
         signer_keypair=manager_key,
         proposal_id=proposal_id,
@@ -203,7 +204,7 @@ def test_manager_propose_manager_has_no_manager():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    proposal = rbac.user.manager.propose.get(
+    proposal = User().manager.propose.get(
         object_id=user.user_id, related_id=manager.user_id
     )
 
@@ -226,10 +227,10 @@ def test_changing_propose_manager():
     """Test changing a manager proposal to a new manager"""
     proposal, user, user_key, _, _ = helper.user.manager.propose.create()
     new_manager, _ = helper.user.create()
-    proposal_id = rbac.addresser.proposal.unique_id()
+    proposal_id = addresser.proposal.unique_id()
     reason = helper.user.reason()
 
-    status = rbac.user.manager.propose.new(
+    status = User().manager.propose.new(
         signer_user_id=user.user_id,
         signer_keypair=user_key,
         proposal_id=proposal_id,
@@ -242,7 +243,7 @@ def test_changing_propose_manager():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    new_proposal = rbac.user.manager.propose.get(
+    new_proposal = User().manager.propose.get(
         object_id=user.user_id, related_id=new_manager.user_id
     )
 

--- a/tests/rbac/common/user/propose_manager_helper.py
+++ b/tests/rbac/common/user/propose_manager_helper.py
@@ -16,7 +16,8 @@
 # pylint: disable=no-member,too-few-public-methods
 import random
 
-from rbac.common import rbac
+from rbac.common import addresser
+from rbac.common.user import User
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common.user.create_user_helper import CreateUserTestHelper
@@ -40,7 +41,7 @@ class ProposeManagerTestHelper:
 
     def id(self):
         """Get a unique identifier"""
-        return rbac.addresser.proposal.unique_id()
+        return addresser.proposal.unique_id()
 
     def reason(self):
         """Get a random reason"""
@@ -52,7 +53,7 @@ class ProposeManagerTestHelper:
         manager, manager_key = helper.user.create()
         proposal_id = self.id()
         reason = helper.user.reason()
-        message = rbac.user.manager.propose.make(
+        message = User().manager.propose.make(
             proposal_id=proposal_id,
             user_id=user.user_id,
             new_manager_id=manager.user_id,
@@ -60,14 +61,14 @@ class ProposeManagerTestHelper:
             metadata=None,
         )
 
-        status = rbac.user.manager.propose.new(
+        status = User().manager.propose.new(
             signer_user_id=user.user_id, signer_keypair=user_key, message=message
         )
 
         assert len(status) == 1
         assert status[0]["status"] == "COMMITTED"
 
-        proposal = rbac.user.manager.propose.get(
+        proposal = User().manager.propose.get(
             object_id=user.user_id, related_id=manager.user_id
         )
 

--- a/tests/rbac/common/user/reject_manager_good_test.py
+++ b/tests/rbac/common/user/reject_manager_good_test.py
@@ -16,7 +16,7 @@
 # pylint: disable=no-member
 import pytest
 
-from rbac.common import rbac
+from rbac.common.user import User
 from rbac.common import protobuf
 from rbac.common.logs import get_default_logger
 from tests.rbac.common import helper
@@ -33,7 +33,7 @@ def test_make():
     reason = helper.user.manager.propose.reason()
     proposal_id = helper.user.manager.propose.id()
     signer_user_id = helper.user.id()
-    message = rbac.user.manager.reject.make(
+    message = User().manager.reject.make(
         proposal_id=proposal_id,
         object_id=object_id,
         related_id=related_id,
@@ -55,10 +55,10 @@ def test_make_addresses():
     related_id = helper.user.id()
     reason = helper.user.manager.propose.reason()
     proposal_id = helper.user.manager.propose.id()
-    proposal_address = rbac.user.manager.reject.address(
+    proposal_address = User().manager.reject.address(
         object_id=object_id, related_id=related_id
     )
-    message = rbac.user.manager.reject.make(
+    message = User().manager.reject.make(
         proposal_id=proposal_id,
         object_id=object_id,
         related_id=related_id,
@@ -66,7 +66,7 @@ def test_make_addresses():
         signer_user_id=object_id,
     )
 
-    inputs, outputs = rbac.user.manager.reject.make_addresses(
+    inputs, outputs = User().manager.reject.make_addresses(
         message=message, signer_user_id=object_id
     )
 
@@ -81,7 +81,7 @@ def test_create():
     proposal, _, _, manager, manager_key = helper.user.manager.propose.create()
     reason = helper.user.manager.propose.reason()
 
-    status = rbac.user.manager.reject.new(
+    status = User().manager.reject.new(
         signer_user_id=manager.user_id,
         signer_keypair=manager_key,
         proposal_id=proposal.proposal_id,
@@ -93,7 +93,7 @@ def test_create():
     assert len(status) == 1
     assert status[0]["status"] == "COMMITTED"
 
-    reject = rbac.user.manager.reject.get(
+    reject = User().manager.reject.get(
         object_id=proposal.object_id, related_id=proposal.related_id
     )
 

--- a/tests/rbac/testdata/role.py
+++ b/tests/rbac/testdata/role.py
@@ -17,7 +17,7 @@
 
 import random
 
-from rbac.common import rbac
+from rbac.common import addresser
 from rbac.common.logs import get_default_logger
 
 LOGGER = get_default_logger(__name__)
@@ -58,14 +58,14 @@ class RoleTestData:
 
     def id(self):
         """Get a test role_id (not created)"""
-        self.last_id = rbac.addresser.role.unique_id()
+        self.last_id = addresser.role.unique_id()
         return self.last_id
 
     def hash(self, value):
         """Returns a 12-byte hash of a given string, unless it is already a
         12-byte hexadecimal string (e.g. as returned by the unique_id function).
         Returns zero bytes if the value is None or falsey"""
-        self.last_hash = rbac.addresser.role.hash(value)
+        self.last_hash = addresser.role.hash(value)
         return self.last_hash
 
     def name(self):

--- a/tests/rbac/testdata/user.py
+++ b/tests/rbac/testdata/user.py
@@ -18,7 +18,7 @@
 import random
 import string
 
-from rbac.common import rbac
+from rbac.common import addresser
 from rbac.common.crypto.keys import Key
 
 
@@ -38,7 +38,7 @@ class UserTestData:
 
     def id(self):
         """Get a test user_id (not created)"""
-        self.last_id = rbac.addresser.user.unique_id()
+        self.last_id = addresser.user.unique_id()
         return self.last_id
 
     def key(self):
@@ -50,7 +50,7 @@ class UserTestData:
         """Returns a 12-byte hash of a given string, unless it is already a
         12-byte hexadecimal string (e.g. as returned by the unique_id function).
         Returns zero bytes if the value is None or falsey"""
-        self.last_hash = rbac.addresser.role.hash(value)
+        self.last_hash = addresser.role.hash(value)
         return self.last_hash
 
     def name(self):


### PR DESCRIPTION
This PR removes the java-type 'singleton' of rbac to follow better code practices and be able to tack sources.  