### PR TITLE
Append build timestamp to version number

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -44,11 +44,22 @@ then
 fi
 
 # update version number
-
-version_number=$(cat ./VERSION) && \
-printf '%s\n' '$d' w q | ed .env &> /dev/null && \
-echo "VERSION_NUMBER=$version_number" >> .env
-
+timestamp=$(date +%d-%m-%Y" "%H:%M:%S)
+    version_number=$(cat ./VERSION)
+if grep -qn VERSION_NUMBER ./.env; then
+    echo "Updating version number and build date..."
+    version_line_num=$(grep -n VERSION_NUMBER ./.env | cut -d : -f 1)
+    sed -ie "$version_line_num s#.*#VERSION_NUMBER=$version_number $timestamp#" ./.env
+    # remove the backup file that sed creates
+    rm ./.enve
+else
+    echo "No VERSION_NUMBER found in .env, you might have a deprecated .env format. Creating VERSION_NUMBER entry..."
+    echo "
+<!--============================================================================
+= version number                                                               =
+=============================================================================-->
+VERSION_NUMBER=$version_number $timestamp" >> ./.env
+fi
 
 if [[ "$1" =~ ^((-{1,2})([Hh]$|[Hh][Ee][Ll][Pp])|)$ ]]; then
     usage; exit 1


### PR DESCRIPTION
* Switch to using `sed` to rewrite the line containing "VERSION_NUMBER"
  * The old method could corrupt legacy .env files.
* The timestamp indicates the build time.

[ Issue: #1394 ]

Signed-off-by: jbobo <j.ned@bobonana.me>