### PR TITLE
R0903

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -44,11 +44,22 @@ then
 fi
 
 # update version number
-
-version_number=$(cat ./VERSION) && \
-printf '%s\n' '$d' w q | ed .env &> /dev/null && \
-echo "VERSION_NUMBER=$version_number" >> .env
-
+timestamp=$(date +%d-%m-%Y" "%H:%M:%S)
+    version_number=$(cat ./VERSION)
+if grep -qn VERSION_NUMBER ./.env; then
+    echo "Updating version number and build date..."
+    version_line_num=$(grep -n VERSION_NUMBER ./.env | cut -d : -f 1)
+    sed -ie "$version_line_num s#.*#VERSION_NUMBER=$version_number $timestamp#" ./.env
+    # remove the backup file that sed creates
+    rm ./.enve
+else
+    echo "No VERSION_NUMBER found in .env, you might have a deprecated .env format. Creating VERSION_NUMBER entry..."
+    echo "
+<!--============================================================================
+= version number                                                               =
+=============================================================================-->
+VERSION_NUMBER=$version_number $timestamp" >> ./.env
+fi
 
 if [[ "$1" =~ ^((-{1,2})([Hh]$|[Hh][Ee][Ll][Pp])|)$ ]]; then
     usage; exit 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ optimize-ast=no
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
 # file where it should appear only once).
-disable=C0301,C0302,C0330,E1101,R0201,R0205,R0401,R0801,R0901,R0902,R0903,R0904,R0913,R0914,R0915,R1701,R1714,W0511,W0612
+disable=C0301,C0302,C0330,E1101,R0201,R0205,R0401,R0801,R0901,R0902,R0904,R0913,R0914,R0915,R1701,R1714,W0511,W0612
 #C0301 - line-too-long
 #C0302 - too-many-lines
 #C0330 - wrong-hanging-indentation
@@ -30,7 +30,6 @@ disable=C0301,C0302,C0330,E1101,R0201,R0205,R0401,R0801,R0901,R0902,R0903,R0904,
 #R0801 - duplicate-code
 #R0901 - too-many-ancestors
 #R0902 - too-many-instance-attributes
-#R0903 - too-few-public-methods
 #R0904 - too-many-public-methods
 #R0913 - too-many-arguments
 #R0914 - too-many-local
@@ -190,7 +189,7 @@ max-parents=7
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7
 # Minimum number of public methods for a class (see R0903).
-min-public-methods=2
+min-public-methods=0
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=20
 # Maximum number of boolean expressions in a if statement

--- a/strict.cfg
+++ b/strict.cfg
@@ -30,8 +30,7 @@ disable=C0301,C0330,R0201,R0801,R0913
 #R0801 - duplicate-code                     # Keep this around, don't like intermediate base classes; increase 
 #R0901 - too-many-ancestors                 # In Strict
 #R0902 - too-many-instance-attributes       # In Strict
-#R0903 - too-few-public-methods             # In Strict
-#R0904 - too-many-public-methods            # In Strict
+#R0904 - too-many-public-methods            # In Strict  
 #R0913 - too-many-arguments                 # Keep disabled (max 5 arguments including self is too little)
 #R0914 - too-many-local                     # In Strict
 #R0915 - too-many-statements                # In Strict
@@ -189,7 +188,7 @@ max-parents=7
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7
 # Minimum number of public methods for a class (see R0903).
-min-public-methods=2
+min-public-methods=0
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=20
 # Maximum number of boolean expressions in a if statement


### PR DESCRIPTION
Remove lint ignore for R0903

Justifying my change, we have several classes that adds logic to the object we are creating. For example, we want stuff to happen when it is created, or we need to perform some operations on it, or control how its displayed, etc. Dictionaries or tuples may not be the best to use in our case so I kept the classes, but set the minimum public methods to 0.

Closes ticket #488